### PR TITLE
feature: 가게 생성 기능 구현 ( #18 )

### DIFF
--- a/src/main/java/jpabook/dashdine/DashDineApplication.java
+++ b/src/main/java/jpabook/dashdine/DashDineApplication.java
@@ -5,6 +5,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 import java.util.TimeZone;
 

--- a/src/main/java/jpabook/dashdine/config/WebSecurityConfig.java
+++ b/src/main/java/jpabook/dashdine/config/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,7 +22,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity // Spring Security 지원을 가능하게 함
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 

--- a/src/main/java/jpabook/dashdine/controller/Restaurant/RestaurantManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/Restaurant/RestaurantManagementController.java
@@ -1,0 +1,35 @@
+package jpabook.dashdine.controller.Restaurant;
+
+import jakarta.validation.Valid;
+import jpabook.dashdine.dto.request.restaurant.CreateRestaurantDto;
+import jpabook.dashdine.dto.response.ApiResponseDto;
+import jpabook.dashdine.security.userdetails.UserDetailsImpl;
+import jpabook.dashdine.service.Restaurant.RestaurantManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.OWNER;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/owner")
+@Secured(OWNER)
+public class RestaurantManagementController {
+
+    private final RestaurantManagementService restaurantManagementService;
+
+    @PostMapping("/create-restaurant")
+    public ResponseEntity<ApiResponseDto> createRestaurant(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody @Valid CreateRestaurantDto createRestaurantDto) {
+        restaurantManagementService.createRestaurant(userDetails.getUser(), createRestaurantDto);
+        return ResponseEntity.ok().body(new ApiResponseDto("가게 생성 성공", HttpStatus.OK.value()));
+    }
+
+}

--- a/src/main/java/jpabook/dashdine/domain/common/Address.java
+++ b/src/main/java/jpabook/dashdine/domain/common/Address.java
@@ -1,0 +1,22 @@
+package jpabook.dashdine.domain.common;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Address {
+
+    private String city;
+    private String street;
+    private String zipcode;
+
+    protected Address() {
+    }
+
+    public Address(String city, String street, String zipcode) {
+        this.city = city;
+        this.street = street;
+        this.zipcode = zipcode;
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/restaurant/Location.java
+++ b/src/main/java/jpabook/dashdine/domain/restaurant/Location.java
@@ -1,0 +1,14 @@
+package jpabook.dashdine.domain.restaurant;
+
+import lombok.Getter;
+
+@Getter
+public class Location { // 추후 record 클래스로 변경 여지
+    private Double latitude;
+    private Double longitude;
+
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/restaurant/Restaurant.java
+++ b/src/main/java/jpabook/dashdine/domain/restaurant/Restaurant.java
@@ -1,0 +1,107 @@
+package jpabook.dashdine.domain.restaurant;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.common.Address;
+import jpabook.dashdine.domain.common.Timestamped;
+import jpabook.dashdine.domain.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.geo.Point;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Table(name = "restaurant")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Restaurant extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 가게 이름
+    @Column(nullable = false)
+    private String name;
+
+    // 가게 전화번호
+    @Column(nullable = false)
+    private String tel;
+
+    // 가게 소개
+    private String info;
+
+    // 최소 주문 가격
+    private int minimumPrice;
+
+    // 영업 시작 시간
+    private String openingTime;
+
+    // 영업 마감 시간
+    private String closingTime;
+
+    // 영업 상태
+    private boolean isOperating;
+
+    // 폐점 여부
+    private boolean isDeleted;
+
+    // 페점 시간
+    private LocalDateTime deletedAt;
+
+    // 주소
+    @Embedded
+    @Column(nullable = false)
+    private Address address;
+
+    // 좌표 중심 값
+//    @Column(nullable = false) 추후 프런트 단계에서 활성화
+    private Point point;
+
+    // 관계 매핑
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 메뉴
+//    @JsonIgnore
+//    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.REMOVE)
+//    List<Menu> menuList = new ArrayList<>();
+
+    @Builder
+    public Restaurant(String name,
+                      String tel, String info, int minimumPrice,
+                      String openingTime, String closingTime,
+                      boolean isOperating, boolean isDeleted,
+                      LocalDateTime deletedAt, Address address,
+                      Point point, User user) {
+        this.name = name;
+        this.tel = tel;
+        this.info = info;
+        this.minimumPrice = minimumPrice;
+        this.openingTime = openingTime;
+        this.closingTime = closingTime;
+        this.isOperating = isOperating;
+        this.isDeleted = isDeleted;
+        this.deletedAt = deletedAt;
+        this.address = address;
+        this.point = point;
+        updateUser(user);
+    }
+
+    private void updateUser(User user) {
+        if(this.user != null) {
+            this.user.getRestaurants().remove(this);
+        }
+
+        this.user = user;
+
+        if(!user.getRestaurants().contains(this)) {
+            user.getRestaurants().add(this);
+        }
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/user/User.java
+++ b/src/main/java/jpabook/dashdine/domain/user/User.java
@@ -1,7 +1,9 @@
 package jpabook.dashdine.domain.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.common.Timestamped;
+import jpabook.dashdine.domain.restaurant.Restaurant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,6 +40,9 @@ public class User extends Timestamped {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PasswordManager> passwordManagers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<Restaurant> restaurants = new ArrayList<>();
 
     public User(String loginId, String password, String email, UserRoleEnum role) {
         this.loginId = loginId;

--- a/src/main/java/jpabook/dashdine/dto/request/restaurant/CreateRestaurantDto.java
+++ b/src/main/java/jpabook/dashdine/dto/request/restaurant/CreateRestaurantDto.java
@@ -1,6 +1,5 @@
 package jpabook.dashdine.dto.request.restaurant;
 
-import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -27,4 +26,13 @@ public class CreateRestaurantDto {
 
     // 영업 마감 시간
     public String closingTime;
+
+    public CreateRestaurantDto() {
+
+    }
+
+    public CreateRestaurantDto(String name, String tel) {
+        this.name = name;
+        this.tel = tel;
+    }
 }

--- a/src/main/java/jpabook/dashdine/dto/request/restaurant/CreateRestaurantDto.java
+++ b/src/main/java/jpabook/dashdine/dto/request/restaurant/CreateRestaurantDto.java
@@ -1,0 +1,30 @@
+package jpabook.dashdine.dto.request.restaurant;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class CreateRestaurantDto {
+    // 가게 이름
+    @NotEmpty(message = "가게 이름을 입력해주세요")
+    public String name;
+
+    // 가게 전화번호
+    @NotEmpty(message = "가게 번호를 입력해주세요")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다")
+    public String tel;
+
+    // 가게 소개
+    public String info;
+
+    // 최소 주문 가격
+    public int minimumPrice;
+
+    // 영업 시작 시간
+    public String openingTime;
+
+    // 영업 마감 시간
+    public String closingTime;
+}

--- a/src/main/java/jpabook/dashdine/repository/Restaurant/RestaurantRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/Restaurant/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package jpabook.dashdine.repository.Restaurant;
+
+import jpabook.dashdine.domain.restaurant.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/jpabook/dashdine/repository/Restaurant/RestaurantRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/Restaurant/RestaurantRepository.java
@@ -2,6 +2,14 @@ package jpabook.dashdine.repository.Restaurant;
 
 import jpabook.dashdine.domain.restaurant.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+    public Restaurant findByIdAndName(Long id, String name);
+
+    @Query("select r.name from Restaurant r where r.user.id = :userId")
+    List<String> findRestaurantNameByUserId(@Param("userId")Long id);
 }

--- a/src/main/java/jpabook/dashdine/service/Restaurant/RestaurantManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/Restaurant/RestaurantManagementService.java
@@ -1,0 +1,57 @@
+package jpabook.dashdine.service.Restaurant;
+
+import jpabook.dashdine.domain.restaurant.Restaurant;
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.dto.request.restaurant.CreateRestaurantDto;
+import jpabook.dashdine.repository.Restaurant.RestaurantRepository;
+import jpabook.dashdine.repository.user.UserRepository;
+import jpabook.dashdine.service.user.UserInfoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "Restaurant Management Service Log")
+public class RestaurantManagementService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final UserInfoService userInfoService;
+
+    // 가게 등록
+    @Transactional
+    public void createRestaurant(User user, CreateRestaurantDto createRestaurantDto) {
+
+        // 유저 조회
+        System.out.println("// =========== 유저 조회 =========== //");
+        User findUser = userInfoService.findUser(user.getLoginId());
+
+        // 본인이 소유한 가게 중 동일한 이름이 있을 경우 예외 발생
+        List<Restaurant> restaurants = findUser.getRestaurants();
+
+        System.out.println("// =========== 목록 조회 =========== //");
+        for (Restaurant restaurant : restaurants) {
+            if (restaurant.getName().equals(createRestaurantDto.name)) {
+                throw new IllegalArgumentException("이미 동일한 이름의 가게를 보유중입니다.");
+            }
+        }
+
+        log.info("식당 생성");
+        Restaurant restaurant = Restaurant.builder()
+                .name(createRestaurantDto.getName())
+                .info(createRestaurantDto.getInfo())
+                .tel(createRestaurantDto.getTel())
+                .minimumPrice(createRestaurantDto.getMinimumPrice())
+                .openingTime(createRestaurantDto.getOpeningTime())
+                .closingTime(createRestaurantDto.getClosingTime())
+                .user(findUser)
+                .build();
+
+        System.out.println("// =========== 저장 =========== //");
+        restaurantRepository.save(restaurant);
+    }
+}

--- a/src/main/java/jpabook/dashdine/service/Restaurant/RestaurantManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/Restaurant/RestaurantManagementService.java
@@ -4,7 +4,6 @@ import jpabook.dashdine.domain.restaurant.Restaurant;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.restaurant.CreateRestaurantDto;
 import jpabook.dashdine.repository.Restaurant.RestaurantRepository;
-import jpabook.dashdine.repository.user.UserRepository;
 import jpabook.dashdine.service.user.UserInfoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,8 @@ spring.batch.job.enabled=false
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
+# OSIV
+spring.jpa.open-in-view=false
 
 # Email
 spring.mail.host=smtp.naver.com

--- a/src/test/java/jpabook/dashdine/service/Restaurant/RestaurantManagementServiceTest.java
+++ b/src/test/java/jpabook/dashdine/service/Restaurant/RestaurantManagementServiceTest.java
@@ -1,0 +1,77 @@
+package jpabook.dashdine.service.Restaurant;
+
+import jpabook.dashdine.domain.restaurant.Restaurant;
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.domain.user.UserRoleEnum;
+import jpabook.dashdine.dto.request.restaurant.CreateRestaurantDto;
+import jpabook.dashdine.repository.Restaurant.RestaurantRepository;
+import jpabook.dashdine.service.user.UserInfoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantManagementServiceTest {
+    @InjectMocks
+    private RestaurantManagementService service;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private UserInfoService userInfoService;
+
+    private User user;
+
+    private CreateRestaurantDto createRestaurantDto;
+
+    @BeforeEach
+    void setUp() {
+        user = new User("userExample", "encodedNewPassword", "email@example.com", UserRoleEnum.OWNER);
+        createRestaurantDto = new CreateRestaurantDto("exampleName1", "000-1111-1111");
+    }
+
+    @Nested
+    @DisplayName("식당 생성 테스트")
+    class testCreateRestaurant {
+
+        @Test
+        @DisplayName("생성 실패 : 중복된 이름")
+        void failToCreateRestaurantWithDuplicateName() {
+            // Given
+            when(userInfoService.findUser(user.getLoginId())).thenReturn(user);
+            when(restaurantRepository.findRestaurantNameByUserId(user.getId())).thenReturn(asList("exampleName1", "exampleName2"));
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, () -> {
+                service.createRestaurant(user, createRestaurantDto);
+            });
+
+            verify(restaurantRepository, times(0)).save(any(Restaurant.class));
+        }
+
+        @Test
+        @DisplayName("생성 성공 : 중복 이름 없음")
+        void successToCreateRestaurant(){
+            // Given
+            when(userInfoService.findUser(user.getLoginId())).thenReturn(user);
+            when(restaurantRepository.findRestaurantNameByUserId(user.getId())).thenReturn(asList("exampleName2", "exampleName3"));
+
+            // When
+            service.createRestaurant(user, createRestaurantDto);
+
+            // Then
+            verify(restaurantRepository, times(1)).save(any(Restaurant.class));
+        }
+    }
+}


### PR DESCRIPTION
# Description

- 식당 생성 API 개발 (/owner/create-restaurant 엔드포인트 추가)
- Restaurant 엔티티에 식당 정보 저장을 위한 빌더 패턴 구현
- RestaurantManagementService 내에 createRestaurant 메소드 구현
  - 사용자 인증 정보를 통해 식당 소유주 확인
  - 동일한 이름을 가진 식당이 있는지 검사 후 예외 처리
  - 식당 정보를 데이터베이스에 저장
- updateUser 메소드를 통한 User와 Restaurant 간의 양방향 연관 관계 관리

# Test
- 생성 실패 테스트 ( 중복된 이름이 있을 경우 )
- 생성 성공 텍스트 ( 중복된 이름이 없을 경우 )