### PR TITLE
feature: 장바구니 추가 기능 구현 ( #27 )

### DIFF
--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
@@ -7,6 +7,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -29,6 +33,9 @@ public class CartMenu {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
+
+    @OneToMany(mappedBy = "cartMenu", cascade = REMOVE)
+    private List<CartMenuOption> cartMenuOptions = new ArrayList<>();
 
     @Builder
     public CartMenu(int count, Cart cart, Menu menu) {

--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenuOption.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenuOption.java
@@ -1,0 +1,35 @@
+package jpabook.dashdine.domain.cart;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.menu.Option;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Table(name = "cart_menu_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartMenuOption {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "cart_menu_id")
+    private CartMenu cartMenu;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+    @Builder
+    public CartMenuOption(CartMenu cartMenu, Option option) {
+        this.cartMenu = cartMenu;
+        this.option = option;
+    }
+}

--- a/src/main/java/jpabook/dashdine/dto/request/cart/CreateCartRequestDto.java
+++ b/src/main/java/jpabook/dashdine/dto/request/cart/CreateCartRequestDto.java
@@ -3,9 +3,12 @@ package jpabook.dashdine.dto.request.cart;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Set;
+
 @Getter
 @NoArgsConstructor
 public class CreateCartRequestDto {
     private Long menuId;
     private int count;
+    private Set<Long> options;
 }

--- a/src/main/java/jpabook/dashdine/dto/response/cart/CartMenuOptionResponseDto.java
+++ b/src/main/java/jpabook/dashdine/dto/response/cart/CartMenuOptionResponseDto.java
@@ -1,0 +1,16 @@
+package jpabook.dashdine.dto.response.cart;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CartMenuOptionResponseDto {
+    private Long menuId;
+    private Long optionId;
+
+    public CartMenuOptionResponseDto(Long menuId, Long optionId) {
+        this.menuId = menuId;
+        this.optionId = optionId;
+    }
+}

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
@@ -1,0 +1,17 @@
+package jpabook.dashdine.repository.cart;
+
+import jpabook.dashdine.domain.cart.CartMenuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, Long> {
+
+    List<CartMenuOption> findByCartMenuId(Long cartMenuId);
+
+    @Query("select cmo.option.id from CartMenuOption cmo where cmo.cartMenu.id = :cartMenuId")
+    Set<Long> findOptionIds(@Param("cartMenuId") Long cartMenuId);
+}

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
@@ -12,6 +12,6 @@ public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, 
 
     List<CartMenuOption> findByCartMenuId(Long cartMenuId);
 
-    @Query("select cmo.option.id from CartMenuOption cmo where cmo.cartMenu.id = :cartMenuId")
-    Set<Long> findOptionIds(@Param("cartMenuId") Long cartMenuId);
+    @Query("select cmo from CartMenuOption cmo where cmo.cartMenu.id in :cartMenuIds")
+    Set<CartMenuOption> findCartMenuOptionByMenuIds(@Param("cartMenuIds")List<Long> cartMenuIds);
 }

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -3,6 +3,8 @@ package jpabook.dashdine.repository.cart;
 import jpabook.dashdine.domain.cart.CartMenu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
-    CartMenu findByCartIdAndMenuId(Long cartId, Long menuId);
+    List<CartMenu> findByCartIdAndMenuId(Long cartId, Long menuId);
 }

--- a/src/main/java/jpabook/dashdine/repository/menu/OptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/menu/OptionRepository.java
@@ -7,8 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface OptionRepository extends JpaRepository<Option, Long> {
+
+
+    List<Option> findByIdIn(Set<Long> optionId);
 
     @Query("select o.content from Option o where o.menu.id = :menuId")
     List<String> findOptionContent(@Param("menuId")Long menuId);

--- a/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
@@ -2,16 +2,25 @@ package jpabook.dashdine.service.cart;
 
 import jpabook.dashdine.domain.cart.Cart;
 import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.cart.CartMenuOption;
 import jpabook.dashdine.domain.menu.Menu;
+import jpabook.dashdine.domain.menu.Option;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.cart.CreateCartRequestDto;
+import jpabook.dashdine.repository.cart.CartMenuOptionRepository;
 import jpabook.dashdine.repository.cart.CartMenuRepository;
 import jpabook.dashdine.repository.cart.CartRepository;
+import jpabook.dashdine.repository.menu.OptionRepository;
 import jpabook.dashdine.service.menu.MenuManagementService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -21,27 +30,60 @@ public class CartManagementService {
 
     private final CartRepository cartRepository;
     private final CartMenuRepository cartMenuRepository;
+    private final CartMenuOptionRepository cartMenuOptionRepository;
+    private final OptionRepository optionRepository;
     private final MenuManagementService menuManagementService;
 
     public void addCart(User user, CreateCartRequestDto createCartRequestDto) {
         // Cart 조회
+        System.out.println("// ============= Cart 조회 ============= //");
         Cart cart = findOneCart(user);
 
         // Menu 조회
+        System.out.println("// ============= Menu 조회 ============= //");
         Menu menu = menuManagementService.findOneMenu(createCartRequestDto.getMenuId());
 
         // CartMenu 조회
-        CartMenu findCartMenu = cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
+        System.out.println("// ============= Cart Menu 조회 ============= //");
+        List<CartMenu> findCartMenus = cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
 
-        if(findCartMenu == null) {
-            CartMenu cartMenu = CartMenu.builder()
-                    .count(createCartRequestDto.getCount())
-                    .cart(cart)
-                    .menu(menu)
+        // Option 조회
+        System.out.println("// ============= Option 조회 ============= //");
+        List<Option> options = optionRepository.findByIdIn(createCartRequestDto.getOptions());
+
+        // cart menu id 를 이용하여 cart menu option 의 option id 를 추출
+
+        Map<Long, Set<Long>> optionidsMap = new HashMap<>();
+
+        System.out.println("// ============= OptionIds 조회 ============= //");
+        for(CartMenu cartMenu : findCartMenus) {
+            optionidsMap.put(cartMenu.getId(), cartMenuOptionRepository.findOptionIds(cartMenu.getId()));
+        }
+
+        // optionIds 와 dto 의 options 가 같은지 확인
+        System.out.println("// ============= optionIds 와 dto 의 options 가 같은지 확인 ============= //");
+        for(CartMenu cartMenu : findCartMenus) {
+            if (optionidsMap.get(cartMenu.getId()).equals(createCartRequestDto.getOptions())) {
+                cartMenu.increaseCount(createCartRequestDto.getCount());
+                return;
+            }
+        }
+
+        System.out.println("// ============= Cart Menu 저장 ============= //");
+        CartMenu newCartMenu = CartMenu.builder()
+                .cart(cart)
+                .menu(menu)
+                .count(createCartRequestDto.getCount())
+                .build();
+        cartMenuRepository.save(newCartMenu);
+
+        System.out.println("// ============= Option 저장 ============= //");
+        for(Option option : options) {
+            CartMenuOption cartMenuOption = CartMenuOption.builder()
+                    .cartMenu(newCartMenu)
+                    .option(option)
                     .build();
-            cartMenuRepository.save(cartMenu);
-        } else {
-            findCartMenu.increaseCount(createCartRequestDto.getCount());
+            cartMenuOptionRepository.save(cartMenuOption);
         }
     }
 
@@ -49,4 +91,9 @@ public class CartManagementService {
         return cartRepository.findByUserId(user.getId())
                 .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
     }
+
+
+    // dto 를 통해 다수의 옵션이 요청되면, 해당 옵션의 id 값을 리스트로 받는다
+    // 메뉴측 메뉴옵션에서 in 절을 통해, 전달 받은 옵션 id 의 객체를 가져온다.
+    // 이후 가져온 id 를 cart_menu 에 함께 저장한다.
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
@@ -1,0 +1,29 @@
+package jpabook.dashdine.service.cart.query;
+
+import jpabook.dashdine.domain.cart.CartMenuOption;
+import jpabook.dashdine.repository.cart.CartMenuOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartMenuOptionQueryService {
+
+    private final CartMenuOptionRepository cartMenuOptionRepository;
+
+    // 복수의 메뉴 Id를 통해 CartMenuOption 조회
+    public Set<CartMenuOption> findCartOptionsByIds(List<Long> menuIds) {
+        return cartMenuOptionRepository.findCartMenuOptionByMenuIds(menuIds);
+    }
+
+    // 복수의 CartMenuOption 을 저장
+    @Transactional
+    public void saveAllCartMenuOption(List<CartMenuOption> cartMenuOptions) {
+        cartMenuOptionRepository.saveAll(cartMenuOptions);
+    }
+}

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -1,0 +1,29 @@
+package jpabook.dashdine.service.cart.query;
+
+import jpabook.dashdine.domain.cart.Cart;
+import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.menu.Menu;
+import jpabook.dashdine.repository.cart.CartMenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartMenuQueryService {
+    private final CartMenuRepository cartMenuRepository;
+
+    // Cart Menu 조회
+    public List<CartMenu> findCartMenus(Cart cart, Menu menu) {
+        return cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
+    }
+
+    // Cart Menu 저장
+    @Transactional
+    public void saveCartMenu(CartMenu cartMenu) {
+        cartMenuRepository.save(cartMenu);
+    }
+}

--- a/src/main/java/jpabook/dashdine/service/menu/OptionManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/menu/OptionManagementService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +49,10 @@ public class OptionManagementService {
         if(optionContent.contains(createOptionRequestDto.getContent())) {
             throw new IllegalArgumentException("동일한 내용의 옵션이 존재합니다.");
         }
+    }
+
+    // ========= Public 메서드 ========= //
+    public List<Option> findOptionsInSet(Set<Long> optionIds) {
+        return optionRepository.findByIdIn(optionIds);
     }
 }


### PR DESCRIPTION
# Description

- 장바구니에 동일한 메뉴가 존재하더라도, 하위 옵션들이 다르다면, 이는 다른 메뉴로 인식하여 저장

- cart menu id 를 이용하여 cart menu option 의 option id 를 추출아여 Map<Long, Set<Long>> 형식으로 저장

- 이때 Key 는 Cart_Menu 의 Id, Value 는 Cart_Menu_Option 의 Id => 즉, 장바구니에 저장된 메뉴 옶션의 Id 를 Value 로 가져감

- 이후 저장된 메뉴 옵션의 Id 와 요청된 메뉴 옵션의 Id 를 비교하여 동일하면 메뉴의 개수만 증가,
다르면 새로운 Cart_Menu 생성하여 저장

- 메뉴 옵션 Id 정합성 검사 간 Set 자료구조를 이용하여 순서 상관없이 검증