### PR TITLE
feature: 장바구니 수정 기능 구현 ( #27 )

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
@@ -37,8 +37,8 @@ public class CartManagementController {
     }
 
     @PutMapping("/cart/{cartMenuId}")
-    public ResponseEntity<ApiResponseDto> updateCart(@PathVariable("cartMenuId")Long cartMenuId, @RequestBody UpdateCartRequestDto updateCartRequestDto) {
-        cartManagementService.updateCart(cartMenuId, updateCartRequestDto);
+    public ResponseEntity<ApiResponseDto> updateCart(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable("cartMenuId")Long cartMenuId, @RequestBody UpdateCartRequestDto updateCartRequestDto) {
+        cartManagementService.updateCart(userDetails.getUser(), cartMenuId, updateCartRequestDto);
         return ResponseEntity.ok().body(new ApiResponseDto("장바구니 수정 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
@@ -36,9 +36,12 @@ public class CartManagementController {
         return cartManagementService.readAllCart(userDetails.getUser());
     }
 
-    @PutMapping("/cart/{cartMenuId}")
-    public ResponseEntity<ApiResponseDto> updateCart(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable("cartMenuId")Long cartMenuId, @RequestBody UpdateCartRequestDto updateCartRequestDto) {
-        cartManagementService.updateCart(userDetails.getUser(), cartMenuId, updateCartRequestDto);
+    @PutMapping("/cart/cart-menu/{cartMenuId}/menu/{menuId}")
+    public ResponseEntity<ApiResponseDto> updateCart(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                     @PathVariable("cartMenuId")Long cartMenuId,
+                                                     @PathVariable("menuId")Long menuId,
+                                                     @RequestBody UpdateCartRequestDto updateCartRequestDto) {
+        cartManagementService.updateCart(userDetails.getUser(), cartMenuId, menuId, updateCartRequestDto);
         return ResponseEntity.ok().body(new ApiResponseDto("장바구니 수정 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
@@ -1,6 +1,7 @@
 package jpabook.dashdine.controller.cart;
 
 import jpabook.dashdine.dto.request.cart.CreateCartRequestDto;
+import jpabook.dashdine.dto.request.cart.UpdateCartRequestDto;
 import jpabook.dashdine.dto.response.ApiResponseDto;
 import jpabook.dashdine.dto.response.cart.CartResponseDto;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
@@ -10,10 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -36,5 +34,11 @@ public class CartManagementController {
     public CartResponseDto readAllCart(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return cartManagementService.readAllCart(userDetails.getUser());
+    }
+
+    @PutMapping("/cart/{cartMenuId}")
+    public ResponseEntity<ApiResponseDto> updateCart(@PathVariable("cartMenuId")Long cartMenuId, @RequestBody UpdateCartRequestDto updateCartRequestDto) {
+        cartManagementService.updateCart(cartMenuId, updateCartRequestDto);
+        return ResponseEntity.ok().body(new ApiResponseDto("장바구니 수정 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -34,7 +34,7 @@ public class CartMenu {
     @JoinColumn(name = "menu_id")
     private Menu menu;
 
-    @OneToMany(mappedBy = "cartMenu", cascade = REMOVE)
+    @OneToMany(mappedBy = "cartMenu", cascade = PERSIST, orphanRemoval = true)
     private List<CartMenuOption> cartMenuOptions = new ArrayList<>();
 
     @Builder
@@ -46,5 +46,9 @@ public class CartMenu {
 
     public void increaseCount(int addCount) {
         this.count += addCount;
+    }
+
+    public void updateCount(int count) {
+        this.count = count;
     }
 }

--- a/src/main/java/jpabook/dashdine/dto/request/cart/UpdateCartRequestDto.java
+++ b/src/main/java/jpabook/dashdine/dto/request/cart/UpdateCartRequestDto.java
@@ -1,0 +1,13 @@
+package jpabook.dashdine.dto.request.cart;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class UpdateCartRequestDto {
+    private int count;
+    private List<Long> options;
+}

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
@@ -14,4 +14,7 @@ public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, 
             "left join fetch cmo.option " +
             "where cmo.cartMenu.id in :cartMenuIds")
     List<CartMenuOption> findCartMenuOptionByMenuIds(@Param("cartMenuIds")List<Long> cartMenuIds);
+
+    List<CartMenuOption> findByCartMenuId(Long cartMenuId);
+
 }

--- a/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
@@ -88,26 +88,33 @@ public class CartManagementService {
 
         findCartMenu.updateCount(updateCartRequestDto.getCount());
 
-        // 요청한 옵션에서 기존 cart menu option 에 존재하면, request dto 에서 제거
-        // 요청한 옵션에서 기존 cart menu option 에 존재하지 않다면, cart menu option 에서 제거 O
+        List<Long> cartMenuOptionIds = findCartMenu.getCartMenuOptions().stream()
+                .map(cmo -> cmo.getOption().getId()).toList();
 
-        // 기존 cart menu option 에 1, 2, 3, 4 이 존재
-        // 그런데 요청 보낸 건 2, 3, 4, 5
-        // 이때 cart menu option 에서는 1을 삭제
+       /*
+       요청한 옵션에서 기존 cart menu option 에 존재하지 않다면, cart menu option 에서 제거
+
+       만약에 cart menu option 에 1, 2, 3, 4 의 값을 가지는 option 이 존재하고,
+       요청 dto 는 2, 3, 4, 5 의 옵션을 가지고 있다면,
+       사용자 측에서 기존 option 에서 " 1 " 은 취소하고, " 5 " 만 추가하길 바란다는 것으로 인지
+       이에 장바구니 메뉴 옵션을 담는 DB 에서 해당 option 은 제거한다.
+       */
 
         findCartMenu.getCartMenuOptions().removeIf(cartMenuOption ->
                 !updateCartRequestDto.getOptions().contains(cartMenuOption.getOption().getId()));
 
-        // 2, 3, 4, 5 를 요청했는데
-        // 기존 cart menu option 에 2, 3, 4 가 존재한다면
-        // 요청한 2, 3, 4, 5에서 2, 3, 4 를 제거
+        /*
+        요청한 옵션에서 기존 cart menu option 에 값이 존재한다면, 요청 request dto 에서 해당 값은 제거
 
-        List<Long> cartMenuOptionIds = findCartMenu.getCartMenuOptions().stream()
-                .map(cmo -> cmo.getOption().getId()).toList();
+        만약에 cart menu option 에 2, 3, 4 가 존재하고 ( 1은 위에 단계에서 지워진 상태다. )
+        request dto 는 2, 3, 4, 5 를 요청했다면,
+        cart menu option 과 사용자가 요청한 옵션이 2, 3, 4 가 겹치니 이는 수정할 필요가 없다고 판단
+        요청 dto 에서 해당 2, 3, 4 값을 제거하고, 최종적으로 option 5 만 새로 추가하고자 하는 것으로 판단한다.
+        */
 
         List<Long> options = updateCartRequestDto.getOptions();
-
         options.removeIf(cartMenuOptionIds::contains);
+
 
         List<Option> optionList = optionManagementService.findOptions(updateCartRequestDto.getOptions());
 
@@ -178,7 +185,7 @@ public class CartManagementService {
     // ============ 전체조회 간 장바구니 목록 Dto 반환 메서드 ============ //
     private List<CartMenuResponseDto> getCartMenuResponseDtos(Cart oneCart, Map<Long, List<CartMenuOption>> cartOptionMap) {
         List<CartMenuResponseDto> cartMenuResponseDtos = oneCart.getCartMenus().stream()
-                .map(cartMenu-> {
+                .map(cartMenu -> {
                     List<CartMenuOptionResponseDto> optionDtos = cartOptionMap.get(cartMenu.getId())
                             .stream()
                             .map(CartMenuOptionResponseDto::new)

--- a/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
@@ -86,6 +86,8 @@ public class CartManagementService {
         System.out.println("// ========== 장바구니 목록 조회 ========== //");
         CartMenu findCartMenu = cartMenuQueryService.findCartMenuById(cartMenuId);
 
+        findCartMenu.updateCount(updateCartRequestDto.getCount());
+
         // 요청한 옵션에서 기존 cart menu option 에 존재하면, request dto 에서 제거
         // 요청한 옵션에서 기존 cart menu option 에 존재하지 않다면, cart menu option 에서 제거 O
 

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
@@ -20,6 +20,11 @@ public class CartMenuOptionQueryService {
         return cartMenuOptionRepository.findCartMenuOptionByMenuIds(cartMenuIds);
     }
 
+    // 단일 메뉴 Id 를 통해 CartMenuOption 조회
+    public List<CartMenuOption> findCartOptionsById(Long cartMenuId) {
+        return cartMenuOptionRepository.findByCartMenuId(cartMenuId);
+    }
+
     // 복수의 CartMenuOption 을 저장
     @Transactional
     public void saveAllCartMenuOption(List<CartMenuOption> cartMenuOptions) {

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -33,4 +33,10 @@ public class CartMenuQueryService {
     public void saveCartMenu(CartMenu cartMenu) {
         cartMenuRepository.save(cartMenu);
     }
+
+    // Cart Menu 삭제
+    @Transactional
+    public void deleteCartMenu(CartMenu cartMenu) {
+        cartMenuRepository.delete(cartMenu);
+    }
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -22,6 +22,12 @@ public class CartMenuQueryService {
         return cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
     }
 
+    // CartMenu 조회 (Cart Menu Id)
+    public CartMenu findCartMenuById(Long cartMenuId) {
+        return cartMenuRepository.findById(cartMenuId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+    }
+
     // Cart Menu 저장
     @Transactional
     public void saveCartMenu(CartMenu cartMenu) {


### PR DESCRIPTION
# Description

- 변경하고자 하는 메뉴 ID를 사용자로부터 받아, 해당 메뉴 정보를 먼저 조회
- 사용자의 장바구니와 조회된 메뉴를 기반으로, 해당 메뉴를 포함하는 장바구니 목록들을 조회
- 해당 목록은 후속 처리에서 중복 메뉴 검증 등에 사용
- 요청된 옵션들과 기존에 장바구니에 담겨있던 옵션들을 비교하여, 더 이상 사용되지 않는 옵션은 제거
- 새로운 옵션이 있다면 추가
- 요청된 옵션이 기존에 있던 옵션과 완전히 동일하다면, 메뉴의 수량만 업데이트
- 만약 옵션에 변화가 있다면, 새로운 옵션을 추가하고 불필요한 옵션을 제거
- 최종적으로, 사용자의 요청에 따라 장바구니 내 메뉴의 수량과 옵션을 업데이트