### PR TITLE
feature: 장바구니 취소 기능 구현 ( # 27  )

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
@@ -36,12 +36,19 @@ public class CartManagementController {
         return cartManagementService.readAllCart(userDetails.getUser());
     }
 
-    @PutMapping("/cart/cart-menu/{cartMenuId}/menu/{menuId}")
+    @PatchMapping("/cart/cart-menu/{cartMenuId}/menu/{menuId}")
     public ResponseEntity<ApiResponseDto> updateCart(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                      @PathVariable("cartMenuId")Long cartMenuId,
                                                      @PathVariable("menuId")Long menuId,
                                                      @RequestBody UpdateCartRequestDto updateCartRequestDto) {
         cartManagementService.updateCart(userDetails.getUser(), cartMenuId, menuId, updateCartRequestDto);
         return ResponseEntity.ok().body(new ApiResponseDto("장바구니 수정 성공", HttpStatus.OK.value()));
+    }
+
+    @PatchMapping("/cart/cart-menu/{cartMenuId}")
+    public ResponseEntity<ApiResponseDto> deleteCart(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                     @PathVariable("cartMenuId")Long cartMenuId) {
+        cartManagementService.deleteCart(userDetails.getUser(), cartMenuId);
+        return ResponseEntity.ok().body(new ApiResponseDto("장바구니 취소 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
@@ -54,4 +54,8 @@ public class CartMenu {
     public void updateCount(int count) {
         this.count = count;
     }
+
+    public void deleteCartMenu() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
@@ -26,6 +26,9 @@ public class CartMenu {
     @Column(name = "count", nullable = false)
     private int count;
 
+    @Column(name = "isDeleted")
+    public boolean isDeleted;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "cart_id")
     private Cart cart;

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
+
+    Optional<CartMenu> findByIdAndIsDeletedFalse(Long cartMenuId);
 
     @Query("select cm from CartMenu cm where cm.cart.id = :cartId and cm.menu.id = :menuId and cm.isDeleted = false")
     List<CartMenu> findByCartIdAndMenuId(@Param("cartId") Long cartId, @Param("menuId") Long menuId);

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -2,11 +2,13 @@ package jpabook.dashdine.repository.cart;
 
 import jpabook.dashdine.domain.cart.CartMenu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
-    List<CartMenu> findByCartIdAndMenuId(Long cartId, Long menuId);
 
-    List<CartMenu> findByCartId(Long cartId);
+    @Query("select cm from CartMenu cm where cm.cart.id = :cartId and cm.menu.id = :menuId and cm.isDeleted = false")
+    List<CartMenu> findByCartIdAndMenuId(@Param("cartId") Long cartId, @Param("menuId") Long menuId);
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -33,4 +33,9 @@ public class CartMenuQueryService {
     public void deleteCartMenu(CartMenu cartMenu) {
         cartMenuRepository.delete(cartMenu);
     }
+
+    public CartMenu findOneCartMenu(Long cartMenuId) {
+        return cartMenuRepository.findByIdAndIsDeletedFalse(cartMenuId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+    }
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -22,12 +22,6 @@ public class CartMenuQueryService {
         return cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
     }
 
-    // CartMenu 조회 (Cart Menu Id)
-    public CartMenu findCartMenuById(Long cartMenuId) {
-        return cartMenuRepository.findById(cartMenuId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
-    }
-
     // Cart Menu 저장
     @Transactional
     public void saveCartMenu(CartMenu cartMenu) {


### PR DESCRIPTION
#Description

- CartMenu 삭제 API 호출시 해당 CartMenu 의 isDeleted 상태값이 true 로 변환

- 삭제된 항목을 조회 시 제외하도록 `CartMenuRepository` 조회 메서드 수정.

- 삭제 로직에서 부모 엔티티의 자식 리스트에서 해당 자식 엔티티 제거 시 메모리 상에서만 반영되는 문제 확인.

- `orphanRemoval` 옵션 대신, 조회 시 삭제된 항목을 필터링하는 방법으로 문제 해결.

- 삭제된 항목을 제외하고 장바구니 목록을 제공하기 위해 서비스 로직 내에서 `filter` 사용하여 `isDeleted`가 `false`인 항목만 반환하도록 처리.