### PR TITLE
feature: 주문 생성 기능 구현

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
+++ b/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
@@ -9,9 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.CUSTOMER;
 
@@ -26,7 +24,7 @@ public class OrderCustomerController {
     public ResponseEntity<ApiResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                       @RequestBody CreateOrderRequestDto requestDto) {
 
-        orderManagementService.createOrder(userDetails.getUser(), requestDto.getCartMenuIds());
+        orderManagementService.createOrder(userDetails.getUser(), requestDto);
 
         return ResponseEntity.ok().body(new ApiResponseDto("주문 성공", HttpStatus.OK.value()));
     }

--- a/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
+++ b/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
@@ -1,0 +1,42 @@
+package jpabook.dashdine.controller.order;
+
+import jpabook.dashdine.dto.request.order.CreateOrderRequestDto;
+import jpabook.dashdine.dto.response.ApiResponseDto;
+import jpabook.dashdine.security.userdetails.UserDetailsImpl;
+import jpabook.dashdine.service.order.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.CUSTOMER;
+
+@RestController
+@RequiredArgsConstructor
+@Secured(CUSTOMER)
+public class OrderCustomerController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/order")
+    public ResponseEntity<ApiResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @RequestBody CreateOrderRequestDto requestDto) {
+        long startTime = System.nanoTime(); // 시작 시간 측정
+
+        orderService.createOrder(userDetails.getUser(), requestDto.getCartMenuIds());
+
+        long endTime = System.nanoTime(); // 종료 시간 측정
+        double executionTime = (endTime - startTime) / 1_000_000.0; // 나노초를 밀리초로 변환
+        System.out.printf("Execution time: %.2f ms\n", executionTime); // 실행 시간 출력
+
+        return ResponseEntity.ok().body(new ApiResponseDto("주문 성공", HttpStatus.OK.value()));
+    }
+
+
+
+
+}

--- a/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
+++ b/src/main/java/jpabook/dashdine/controller/order/OrderCustomerController.java
@@ -3,7 +3,7 @@ package jpabook.dashdine.controller.order;
 import jpabook.dashdine.dto.request.order.CreateOrderRequestDto;
 import jpabook.dashdine.dto.response.ApiResponseDto;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
-import jpabook.dashdine.service.order.OrderService;
+import jpabook.dashdine.service.order.OrderManagementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +20,13 @@ import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.CUSTOMER;
 @Secured(CUSTOMER)
 public class OrderCustomerController {
 
-    private final OrderService orderService;
+    private final OrderManagementService orderManagementService;
 
     @PostMapping("/order")
     public ResponseEntity<ApiResponseDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                       @RequestBody CreateOrderRequestDto requestDto) {
-        long startTime = System.nanoTime(); // 시작 시간 측정
 
-        orderService.createOrder(userDetails.getUser(), requestDto.getCartMenuIds());
-
-        long endTime = System.nanoTime(); // 종료 시간 측정
-        double executionTime = (endTime - startTime) / 1_000_000.0; // 나노초를 밀리초로 변환
-        System.out.printf("Execution time: %.2f ms\n", executionTime); // 실행 시간 출력
+        orderManagementService.createOrder(userDetails.getUser(), requestDto.getCartMenuIds());
 
         return ResponseEntity.ok().body(new ApiResponseDto("주문 성공", HttpStatus.OK.value()));
     }

--- a/src/main/java/jpabook/dashdine/domain/order/Delivery.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Delivery.java
@@ -3,10 +3,7 @@ package jpabook.dashdine.domain.order;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.common.Address;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +12,6 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
-@Setter
 @Table(name = "delivery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery {
@@ -24,7 +20,9 @@ public class Delivery {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    private LocalDateTime arrivalAt;
+    private String cancelContent;
+
+    private LocalDateTime arrivedAt;
 
     private LocalDateTime estimatedAt;
 
@@ -41,4 +39,14 @@ public class Delivery {
     @OneToOne(mappedBy = "delivery", fetch = LAZY)
     private Order order;
 
+    @Builder
+    public Delivery(DeliveryStatus deliveryStatus, Address address) {
+        this.deliveryStatus = deliveryStatus;
+        this.address = address;
+    }
+
+    //== 연관관계 메서드 ==//
+    public void updateOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/src/main/java/jpabook/dashdine/domain/order/Delivery.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Delivery.java
@@ -22,10 +22,6 @@ public class Delivery {
 
     private String cancelContent;
 
-    private LocalDateTime arrivedAt;
-
-    private LocalDateTime estimatedAt;
-
     private boolean isDeleted;
 
     @Enumerated(EnumType.STRING)
@@ -34,6 +30,12 @@ public class Delivery {
     @Embedded
     @Column(nullable = false)
     private Address address;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime arrivedAt;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime estimatedAt;
 
     @JsonIgnore
     @OneToOne(mappedBy = "delivery", fetch = LAZY)

--- a/src/main/java/jpabook/dashdine/domain/order/Delivery.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Delivery.java
@@ -1,0 +1,38 @@
+package jpabook.dashdine.domain.order;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.common.Address;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "delivery")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Delivery {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private LocalDateTime arrivalAt;
+
+    private LocalDateTime estimatedAt;
+
+    private boolean isDeleted;
+
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus deliveryStatus;
+
+    @Embedded
+    @Column(nullable = false)
+    private Address address;
+
+}

--- a/src/main/java/jpabook/dashdine/domain/order/Delivery.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Delivery.java
@@ -1,5 +1,6 @@
 package jpabook.dashdine.domain.order;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.common.Address;
 import lombok.AccessLevel;
@@ -9,6 +10,7 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
@@ -34,5 +36,9 @@ public class Delivery {
     @Embedded
     @Column(nullable = false)
     private Address address;
+
+    @JsonIgnore
+    @OneToOne(mappedBy = "delivery", fetch = LAZY)
+    private Order order;
 
 }

--- a/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
+++ b/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
@@ -1,0 +1,24 @@
+package jpabook.dashdine.domain.order;
+
+import lombok.Getter;
+
+@Getter
+public enum DeliveryStatus {
+    PENDING(Delivery.PENDING),  // 준비 중
+    SHIPPED(Delivery.SHIPPED),  // 배송 중
+    DELIVERED(Delivery.DELIVERED); // 배송 완료
+
+
+    private final String delivery;
+
+    DeliveryStatus(String delivery) {
+        this.delivery = delivery;
+    }
+
+    public static class Delivery {
+        public static final String PENDING = "STATUS_PENDING";
+        public static final String SHIPPED = "STATUS_SHIPPED";
+        public static final String DELIVERED = "STATUS_DELIVERED";
+
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
+++ b/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum DeliveryStatus {
+
     PENDING(Delivery.PENDING),  // 준비 중
     SHIPPED(Delivery.SHIPPED),  // 배송 중
     DELIVERED(Delivery.DELIVERED); // 배송 완료

--- a/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
+++ b/src/main/java/jpabook/dashdine/domain/order/DeliveryStatus.java
@@ -5,21 +5,20 @@ import lombok.Getter;
 @Getter
 public enum DeliveryStatus {
 
-    PENDING(Delivery.PENDING),  // 준비 중
-    SHIPPED(Delivery.SHIPPED),  // 배송 중
-    DELIVERED(Delivery.DELIVERED); // 배송 완료
+    PENDING(Status.PENDING),  // 준비 중
+    SHIPPED(Status.SHIPPED),  // 배송 중
+    DELIVERED(Status.DELIVERED); // 배송 완료
 
 
-    private final String delivery;
+    private final String status;
 
-    DeliveryStatus(String delivery) {
-        this.delivery = delivery;
+    DeliveryStatus(String status) {
+        this.status = status;
     }
 
-    public static class Delivery {
+    public static class Status {
         public static final String PENDING = "STATUS_PENDING";
         public static final String SHIPPED = "STATUS_SHIPPED";
         public static final String DELIVERED = "STATUS_DELIVERED";
-
     }
 }

--- a/src/main/java/jpabook/dashdine/domain/order/Order.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Order.java
@@ -59,7 +59,7 @@ public class Order {
     }
 
     public void addOrderMenu(List<OrderMenu> orderMenus) {
-        this.orderMenus = orderMenus;
+        this.orderMenus.addAll(orderMenus);
         orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
     }
 

--- a/src/main/java/jpabook/dashdine/domain/order/Order.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Order.java
@@ -1,0 +1,75 @@
+package jpabook.dashdine.domain.order;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.user.User;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private boolean isDeleted;
+
+    private String cancelContent;
+
+    private boolean orderStatus;
+
+    @CreatedDate
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @Column
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime deletedAt;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "order", cascade = PERSIST, orphanRemoval = true)
+    private List<OrderMenu> orderMenus = new ArrayList<>();
+
+    @Builder
+    public Order(Long id, boolean isDeleted, String cancelContent, boolean orderStatus, LocalDateTime createdAt, LocalDateTime deletedAt, User user, List<OrderMenu> orderMenus) {
+        this.id = id;
+        this.isDeleted = isDeleted;
+        this.cancelContent = cancelContent;
+        this.orderStatus = orderStatus;
+        this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
+        this.user = user;
+        this.orderMenus = orderMenus;
+    }
+
+    public void addOrderMenu(List<OrderMenu> orderMenus) {
+        this.orderMenus = orderMenus;
+        orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
+    }
+
+    //==생성 메서드==//
+    public static Order createOrder(User findUser, List<OrderMenu> orderMenu) {
+        Order order = Order.builder()
+                .user(findUser)
+                .orderStatus(true)
+                .build();
+        order.addOrderMenu(orderMenu);
+
+        return order;
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/order/Order.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Order.java
@@ -1,5 +1,6 @@
 package jpabook.dashdine.domain.order;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.user.User;
 import lombok.*;
@@ -46,6 +47,12 @@ public class Order {
 
     @OneToMany(mappedBy = "order", cascade = PERSIST, orphanRemoval = true)
     private List<OrderMenu> orderMenus = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "delivery_id")
+    private Delivery delivery;
+
 
     @Builder
     public Order(boolean orderStatus) {

--- a/src/main/java/jpabook/dashdine/domain/order/Order.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Order.java
@@ -65,17 +65,23 @@ public class Order {
         user.getOrders().add(this);
     }
 
+    private void updateDelivery(Delivery delivery) {
+        this.delivery = delivery;
+        delivery.updateOrder(this);
+    }
+
     public void addOrderMenu(List<OrderMenu> orderMenus) {
         this.orderMenus.addAll(orderMenus);
         orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
     }
 
     //== 생성 메서드 ==//
-    public static Order createOrder(User findUser, List<OrderMenu> orderMenu) {
+    public static Order createOrder(User findUser, Delivery delivery, List<OrderMenu> orderMenu) {
         Order order = Order.builder()
                 .orderStatus(true)
                 .build();
         order.updateUser(findUser);
+        order.updateDelivery(delivery);
         order.addOrderMenu(orderMenu);
 
         return order;

--- a/src/main/java/jpabook/dashdine/domain/order/Order.java
+++ b/src/main/java/jpabook/dashdine/domain/order/Order.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jpabook.dashdine.domain.user.User;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Getter
 @Setter
 @Table(name = "orders")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
     @Id
@@ -46,15 +48,14 @@ public class Order {
     private List<OrderMenu> orderMenus = new ArrayList<>();
 
     @Builder
-    public Order(Long id, boolean isDeleted, String cancelContent, boolean orderStatus, LocalDateTime createdAt, LocalDateTime deletedAt, User user, List<OrderMenu> orderMenus) {
-        this.id = id;
-        this.isDeleted = isDeleted;
-        this.cancelContent = cancelContent;
+    public Order(boolean orderStatus) {
         this.orderStatus = orderStatus;
-        this.createdAt = createdAt;
-        this.deletedAt = deletedAt;
+    }
+
+    //== 연관관계 메서드 ==//
+    public void updateUser(User user) {
         this.user = user;
-        this.orderMenus = orderMenus;
+        user.getOrders().add(this);
     }
 
     public void addOrderMenu(List<OrderMenu> orderMenus) {
@@ -62,12 +63,12 @@ public class Order {
         orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
     }
 
-    //==생성 메서드==//
+    //== 생성 메서드 ==//
     public static Order createOrder(User findUser, List<OrderMenu> orderMenu) {
         Order order = Order.builder()
-                .user(findUser)
                 .orderStatus(true)
                 .build();
+        order.updateUser(findUser);
         order.addOrderMenu(orderMenu);
 
         return order;

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
@@ -1,0 +1,57 @@
+package jpabook.dashdine.domain.order;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.menu.Menu;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Table(name = "order_menu")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderMenu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    private Menu menu;
+
+    @ManyToOne(fetch = LAZY)
+    private Order order;
+
+    private int orderPrice;
+    private int count;
+
+    @Builder
+    public OrderMenu(Long id, Menu menu, Order order, int orderPrice, int count) {
+        this.id = id;
+        this.menu = menu;
+        this.order = order;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+
+    public void updateOrder(Order order) {
+        this.order = order;
+    }
+
+    public static List<OrderMenu> createOrderItem(List<CartMenu> cartMenus) {
+        return cartMenus.stream()
+                .map(cartMenu -> OrderMenu.builder()
+                        .menu(cartMenu.getMenu())
+                        .orderPrice(cartMenu.getMenu().getPrice())
+                        .count(cartMenu.getCount())
+                        .build()
+                ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
@@ -9,9 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static jakarta.persistence.CascadeType.PERSIST;
@@ -57,34 +55,38 @@ public class OrderMenu {
 
     //== 생성 메서드 ==//
     public static List<OrderMenu> createOrderItem(List<CartMenu> cartMenus, Map<CartMenu, List<CartMenuOption>> cartMenuOptionsMap) {
-        if(cartMenus.isEmpty()) {
+        if (cartMenus.isEmpty()) {
             throw new IllegalArgumentException("해당 항목이 존재하지 않습니다.");
         }
 
         List<OrderMenu> orderMenus = cartMenus.stream()
                 .map(cartMenu -> {
                             OrderMenu orderMenu = OrderMenu.builder()
+                                    .orderPrice(cartMenu.getMenu().getPrice() * cartMenu.getCount())
                                     .menu(cartMenu.getMenu())
                                     .count(cartMenu.getCount())
                                     .build();
 
                             System.out.println("// ======= 주문 목록 옵션 생성 ======= //");
-                            List<OrderMenuOption> orderOptions = cartMenuOptionsMap.get(cartMenu).stream()
-                                    .map(cartMenuOption -> {
-                                                OrderMenuOption orderMenuOption = OrderMenuOption.builder()
-                                                        .option(cartMenuOption.getOption())
-                                                        .build();
-                                                orderMenuOption.updateOrderMenu(orderMenu);
-                                                return orderMenuOption;
-                                            }
-                                    )
-                                    .collect(Collectors.toList());
-                            orderMenu.getOrderMenuOptions().addAll(orderOptions);
+                            if (cartMenuOptionsMap.get(cartMenu) != null) {
+                                cartMenuOptionsMap.get(cartMenu)
+                                        .stream()
+                                        .map(cartMenuOption ->
+                                                {
+                                                    OrderMenuOption orderMenuOption = OrderMenuOption.builder()
+                                                            .optionPrice(cartMenuOption.getOption().getPrice())
+                                                            .option(cartMenuOption.getOption())
+                                                            .build();
+                                                    orderMenuOption.updateOrderMenu(orderMenu);
+                                                    return orderMenuOption;
+                                                }
+                                        )
+                                        .collect(Collectors.toList());
+                            }
                             return orderMenu;
                         }
                 ).collect(Collectors.toList());
 
         return orderMenus;
     }
-
 }

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
@@ -41,17 +41,24 @@ public class OrderMenu {
         this.count = count;
     }
 
+    //== 연관관계 메서드 ==//
     public void updateOrder(Order order) {
         this.order = order;
+        order.getOrderMenus().add(this);
     }
 
     public static List<OrderMenu> createOrderItem(List<CartMenu> cartMenus) {
+
+        if(cartMenus.isEmpty()) {
+            throw new IllegalArgumentException("해당 항목이 존재하지 않습니다.");
+        }
+
         return cartMenus.stream()
                 .map(cartMenu -> OrderMenu.builder()
                         .menu(cartMenu.getMenu())
-                        .orderPrice(cartMenu.getMenu().getPrice())
                         .count(cartMenu.getCount())
                         .build()
                 ).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenu.java
@@ -2,6 +2,7 @@ package jpabook.dashdine.domain.order;
 
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.cart.CartMenuOption;
 import jpabook.dashdine.domain.menu.Menu;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static jakarta.persistence.CascadeType.PERSIST;
@@ -54,7 +56,7 @@ public class OrderMenu {
 
 
     //== 생성 메서드 ==//
-    public static List<OrderMenu> createOrderItem(List<CartMenu> cartMenus) {
+    public static List<OrderMenu> createOrderItem(List<CartMenu> cartMenus, Map<CartMenu, List<CartMenuOption>> cartMenuOptionsMap) {
         if(cartMenus.isEmpty()) {
             throw new IllegalArgumentException("해당 항목이 존재하지 않습니다.");
         }
@@ -67,7 +69,7 @@ public class OrderMenu {
                                     .build();
 
                             System.out.println("// ======= 주문 목록 옵션 생성 ======= //");
-                            List<OrderMenuOption> orderOptions = cartMenu.getCartMenuOptions().stream()
+                            List<OrderMenuOption> orderOptions = cartMenuOptionsMap.get(cartMenu).stream()
                                     .map(cartMenuOption -> {
                                                 OrderMenuOption orderMenuOption = OrderMenuOption.builder()
                                                         .option(cartMenuOption.getOption())

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenuOption.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenuOption.java
@@ -1,0 +1,41 @@
+package jpabook.dashdine.domain.order;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.menu.Option;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Table(name = "order_menu_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderMenuOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_menu_id")
+    private OrderMenu orderMenu;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "menu_option_id")
+    private Option option;
+
+    @Builder
+    public OrderMenuOption(Long id, OrderMenu orderMenu, Option option) {
+        this.id = id;
+        this.orderMenu = orderMenu;
+        this.option = option;
+    }
+
+    //== 연관관계 메서드 ==//
+    public void updateOrderMenu(OrderMenu orderMenu) {
+        this.orderMenu = orderMenu;
+        orderMenu.getOrderMenuOptions().add(this);
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/order/OrderMenuOption.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderMenuOption.java
@@ -18,6 +18,8 @@ public class OrderMenuOption {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private int optionPrice;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "order_menu_id")
     private OrderMenu orderMenu;
@@ -27,8 +29,8 @@ public class OrderMenuOption {
     private Option option;
 
     @Builder
-    public OrderMenuOption(Long id, OrderMenu orderMenu, Option option) {
-        this.id = id;
+    public OrderMenuOption(int optionPrice, OrderMenu orderMenu, Option option) {
+        this.optionPrice = optionPrice;
         this.orderMenu = orderMenu;
         this.option = option;
     }

--- a/src/main/java/jpabook/dashdine/domain/order/OrderStatus.java
+++ b/src/main/java/jpabook/dashdine/domain/order/OrderStatus.java
@@ -1,0 +1,22 @@
+package jpabook.dashdine.domain.order;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+
+    ORDER(Status.ORDER),  // 주문 완료
+    CANCEL(Status.CANCEL);  // 주문 취소
+
+    private final String status;
+
+    OrderStatus(String status) {
+        this.status = status;
+    }
+
+    public static class Status {
+        public static final String ORDER = "ORDER_COMPLETED";
+        public static final String CANCEL = "ORDER_CANCEL";
+
+    }
+}

--- a/src/main/java/jpabook/dashdine/domain/user/User.java
+++ b/src/main/java/jpabook/dashdine/domain/user/User.java
@@ -3,6 +3,7 @@ package jpabook.dashdine.domain.user;
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.cart.Cart;
 import jpabook.dashdine.domain.common.Timestamped;
+import jpabook.dashdine.domain.order.Order;
 import jpabook.dashdine.domain.restaurant.Restaurant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -44,6 +45,9 @@ public class User extends Timestamped {
 
     @OneToMany(mappedBy = "user", cascade = REMOVE)
     private List<Restaurant> restaurants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = REMOVE)
+    private List<Order> orders = new ArrayList<>();
 
     @OneToOne(fetch = LAZY, cascade = ALL)
     @JoinColumn(name = "cart_id")

--- a/src/main/java/jpabook/dashdine/domain/user/User.java
+++ b/src/main/java/jpabook/dashdine/domain/user/User.java
@@ -2,6 +2,7 @@ package jpabook.dashdine.domain.user;
 
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.cart.Cart;
+import jpabook.dashdine.domain.common.Address;
 import jpabook.dashdine.domain.common.Timestamped;
 import jpabook.dashdine.domain.order.Order;
 import jpabook.dashdine.domain.restaurant.Restaurant;
@@ -39,6 +40,11 @@ public class User extends Timestamped {
     private UserRoleEnum role;
 
     private boolean isDeleted;
+
+    @Embedded
+    @Column(nullable = false)
+    private Address address;
+
 
     @OneToMany(mappedBy = "user", cascade = REMOVE)
     private List<PasswordManager> passwordManagers = new ArrayList<>();

--- a/src/main/java/jpabook/dashdine/dto/request/order/CreateOrderRequestDto.java
+++ b/src/main/java/jpabook/dashdine/dto/request/order/CreateOrderRequestDto.java
@@ -1,0 +1,12 @@
+package jpabook.dashdine.dto.request.order;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateOrderRequestDto {
+    private List<Long> cartMenuIds;
+}

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
@@ -1,7 +1,9 @@
 package jpabook.dashdine.repository.cart;
 
+import jpabook.dashdine.domain.cart.CartMenu;
 import jpabook.dashdine.domain.cart.CartMenuOption;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,5 +18,9 @@ public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, 
     List<CartMenuOption> findCartMenuOptionByMenuIds(@Param("cartMenuIds")List<Long> cartMenuIds);
 
     List<CartMenuOption> findByCartMenuId(Long cartMenuId);
+
+    @Modifying
+    @Query("delete from CartMenuOption cmo where cmo.cartMenu in :cartMenus")
+    void deleteAllByCartMenu(@Param("cartMenus")List<CartMenu> cartMenus);
 
 }

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -2,6 +2,7 @@ package jpabook.dashdine.repository.cart;
 
 import jpabook.dashdine.domain.cart.CartMenu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +15,11 @@ public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
 
     @Query("select cm from CartMenu cm where cm.cart.id = :cartId and cm.menu.id = :menuId and cm.isDeleted = false")
     List<CartMenu> findByCartIdAndMenuId(@Param("cartId") Long cartId, @Param("menuId") Long menuId);
+
+    @Query("select cm from CartMenu cm where cm.id in :cartMenuIds and cm.isDeleted = false")
+    List<CartMenu> findCartMenus(@Param("cartMenuIds") List<Long> cartMenuIds);
+
+    @Modifying
+    @Query("delete from CartMenu cm where cm in :cartMenus")
+    void deleteAllByCartMenus(@Param("cartMenus") List<CartMenu> cartMenus);
 }

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -16,7 +16,9 @@ public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
     @Query("select cm from CartMenu cm where cm.cart.id = :cartId and cm.menu.id = :menuId and cm.isDeleted = false")
     List<CartMenu> findByCartIdAndMenuId(@Param("cartId") Long cartId, @Param("menuId") Long menuId);
 
-    @Query("select cm from CartMenu cm where cm.id in :cartMenuIds and cm.isDeleted = false")
+    @Query("select cm from CartMenu cm " +
+            "left join fetch cm.menu " +
+            "where cm.id in :cartMenuIds and cm.isDeleted = false")
     List<CartMenu> findCartMenus(@Param("cartMenuIds") List<Long> cartMenuIds);
 
     @Modifying

--- a/src/main/java/jpabook/dashdine/repository/order/OrderRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/order/OrderRepository.java
@@ -1,0 +1,7 @@
+package jpabook.dashdine.repository.order;
+
+import jpabook.dashdine.domain.order.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/CartManagementService.java
@@ -205,7 +205,7 @@ public class CartManagementService {
 
 
     // ============ Private 메서드 ============ //
-    private Cart findOneCart(User user) {
+    public Cart findOneCart(User user) {
         return cartRepository.findByUserId(user.getId())
                 .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
     }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
@@ -21,11 +21,6 @@ public class CartMenuOptionQueryService {
         return cartMenuOptionRepository.findCartMenuOptionByMenuIds(cartMenuIds);
     }
 
-    // 단일 메뉴 Id 를 통해 CartMenuOption 조회
-    public List<CartMenuOption> findCartOptionsById(Long cartMenuId) {
-        return cartMenuOptionRepository.findByCartMenuId(cartMenuId);
-    }
-
     // 복수의 CartMenuOption 을 저장
     @Transactional
     public void saveAllCartMenuOption(List<CartMenuOption> cartMenuOptions) {

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuOptionQueryService.java
@@ -1,5 +1,6 @@
 package jpabook.dashdine.service.cart.query;
 
+import jpabook.dashdine.domain.cart.CartMenu;
 import jpabook.dashdine.domain.cart.CartMenuOption;
 import jpabook.dashdine.repository.cart.CartMenuOptionRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,11 @@ public class CartMenuOptionQueryService {
     @Transactional
     public void saveAllCartMenuOption(List<CartMenuOption> cartMenuOptions) {
         cartMenuOptionRepository.saveAll(cartMenuOptions);
+    }
+
+    // 복수의 CartMenuOption 삭제
+    @Transactional
+    public void deleteAllCartMenuOptions(List<CartMenu> cartMenus) {
+        cartMenuOptionRepository.deleteAllByCartMenu(cartMenus);
     }
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -44,6 +44,11 @@ public class CartMenuQueryService {
         cartMenuRepository.deleteAllByCartMenus(cartMenus);
     }
 
+    @Transactional
+    public void deleteAll(List<CartMenu> cartMenus) {
+        cartMenuRepository.deleteAll(cartMenus);
+    }
+
     public CartMenu findOneCartMenu(Long cartMenuId) {
         return cartMenuRepository.findByIdAndIsDeletedFalse(cartMenuId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -44,10 +44,6 @@ public class CartMenuQueryService {
         cartMenuRepository.deleteAllByCartMenus(cartMenus);
     }
 
-    @Transactional
-    public void deleteAll(List<CartMenu> cartMenus) {
-        cartMenuRepository.deleteAll(cartMenus);
-    }
 
     public CartMenu findOneCartMenu(Long cartMenuId) {
         return cartMenuRepository.findByIdAndIsDeletedFalse(cartMenuId)

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -22,6 +22,11 @@ public class CartMenuQueryService {
         return cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId());
     }
 
+    // Cart Menu 조회 CartMenu Ids
+    public List<CartMenu> findCartMenus(List<Long> cartMenuIds) {
+        return cartMenuRepository.findCartMenus(cartMenuIds);
+    }
+
     // Cart Menu 저장
     @Transactional
     public void saveCartMenu(CartMenu cartMenu) {
@@ -32,6 +37,11 @@ public class CartMenuQueryService {
     @Transactional
     public void deleteCartMenu(CartMenu cartMenu) {
         cartMenuRepository.delete(cartMenu);
+    }
+
+    @Transactional
+    public void deleteCartMenus(List<CartMenu> cartMenus) {
+        cartMenuRepository.deleteAllByCartMenus(cartMenus);
     }
 
     public CartMenu findOneCartMenu(Long cartMenuId) {

--- a/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 @Slf4j(topic = "Order Management Service Log")
-public class OrderService {
+public class OrderManagementService {
 
     private final OrderRepository orderRepository;
     private final UserInfoService userInfoService;
@@ -29,9 +29,7 @@ public class OrderService {
         System.out.println("// ======= 유저 조회 ======= //");
         User findUser = userInfoService.findUser(user.getLoginId());
 
-        System.out.println("// ======= 장바구니 목록 ======= //");
         List<CartMenu> cartMenus = cartMenuQueryService.findCartMenus(cartMenuIds);
-
 
         // 주문 상품 생성
         System.out.println("// ======= 주문 상품 생성 ======= //");
@@ -46,6 +44,6 @@ public class OrderService {
 
         // 장바구니 비우기
         System.out.println("// ======= 장바구니 비우기 ======= //");
-        cartMenuQueryService.deleteCartMenus(cartMenus);
+        cartMenuQueryService.deleteAll(cartMenus);
     }
 }

--- a/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
@@ -1,10 +1,12 @@
 package jpabook.dashdine.service.order;
 
 import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.cart.CartMenuOption;
 import jpabook.dashdine.domain.order.Order;
 import jpabook.dashdine.domain.order.OrderMenu;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.repository.order.OrderRepository;
+import jpabook.dashdine.service.cart.query.CartMenuOptionQueryService;
 import jpabook.dashdine.service.cart.query.CartMenuQueryService;
 import jpabook.dashdine.service.user.UserInfoService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,27 +27,59 @@ public class OrderManagementService {
     private final OrderRepository orderRepository;
     private final UserInfoService userInfoService;
     private final CartMenuQueryService cartMenuQueryService;
+    private final CartMenuOptionQueryService cartMenuOptionQueryService;
 
     public void createOrder(User user, List<Long> cartMenuIds) {
         // 엔티티 조회
-        System.out.println("// ======= 유저 조회 ======= //");
+
+        /*
+        유저 조회
+        */
         User findUser = userInfoService.findUser(user.getLoginId());
 
+         /*
+        장바구니 목록 조회
+        */
         List<CartMenu> cartMenus = cartMenuQueryService.findCartMenus(cartMenuIds);
 
+         /*
+        장바구니 각 목록에 매핑된 옵션 조회
+
+        옵션을 조회할 때 목록의 in 절을 통해 목록의 Id 와 관련된 객체들을 한 번에 가져온다.
+        이는 N + 1 문제를 방지하기 위함이다.
+        이후 각 목록을 Key, 이에 매핑된 Option 들을 value 로 가지는 Map 을 생성한다.
+        해당 Map 은 주문을 생성할 때 각 목록에 해당하는 option 들을 매핑할 때 사용된다.
+        */
+        Map<CartMenu, List<CartMenuOption>> cartMenuOptionsMap = getCartMenuOptionsMap(cartMenuIds);
+
         // 주문 상품 생성
-        System.out.println("// ======= 주문 상품 생성 ======= //");
-        List<OrderMenu> orderMenu = OrderMenu.createOrderItem(cartMenus);
+        List<OrderMenu> orderMenu = OrderMenu.createOrderItem(cartMenus,cartMenuOptionsMap);
 
         // 주문 생성
-        System.out.println("// ======= 주문 생성 ======= //");
         Order order = Order.createOrder(findUser, orderMenu);
 
-        System.out.println("// ======= 주문 저장 ======= //");
         orderRepository.save(order);
 
-        // 장바구니 비우기
+        /*
+        장바구니 비우기
+
+        각 요소마다 delete 쿼리가 발생하는 현상을 방지하기 위해
+        먼저 cart_menu_option 을 삭제 후 cart_menu 를 삭제한다.
+        JPQL 을 이용하여 cart_menu 삭제 시 이와 연관된 cart_menu_option 들을 한 번에 지우는 것에는 한계가 있어, 이와 같이 구성했다.
+        */
         System.out.println("// ======= 장바구니 비우기 ======= //");
-        cartMenuQueryService.deleteAll(cartMenus);
+        emptyCart(cartMenus);
+    }
+
+    private Map<CartMenu, List<CartMenuOption>> getCartMenuOptionsMap(List<Long> cartMenuIds) {
+        List<CartMenuOption> cartMenuOptions = cartMenuOptionQueryService.findCartOptionsByIds(cartMenuIds);
+
+        return cartMenuOptions.stream()
+                .collect(Collectors.groupingBy(CartMenuOption::getCartMenu));
+    }
+
+    private void emptyCart(List<CartMenu> cartMenus) {
+        cartMenuOptionQueryService.deleteAllCartMenuOptions(cartMenus);
+        cartMenuQueryService.deleteCartMenus(cartMenus);
     }
 }

--- a/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/order/OrderManagementService.java
@@ -2,6 +2,8 @@ package jpabook.dashdine.service.order;
 
 import jpabook.dashdine.domain.cart.CartMenu;
 import jpabook.dashdine.domain.cart.CartMenuOption;
+import jpabook.dashdine.domain.order.Delivery;
+import jpabook.dashdine.domain.order.DeliveryStatus;
 import jpabook.dashdine.domain.order.Order;
 import jpabook.dashdine.domain.order.OrderMenu;
 import jpabook.dashdine.domain.user.User;
@@ -10,7 +12,6 @@ import jpabook.dashdine.service.cart.query.CartMenuOptionQueryService;
 import jpabook.dashdine.service.cart.query.CartMenuQueryService;
 import jpabook.dashdine.service.user.UserInfoService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +22,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j(topic = "Order Management Service Log")
 public class OrderManagementService {
 
     private final OrderRepository orderRepository;
@@ -52,11 +52,17 @@ public class OrderManagementService {
         */
         Map<CartMenu, List<CartMenuOption>> cartMenuOptionsMap = getCartMenuOptionsMap(cartMenuIds);
 
+        // 배송정보 생성
+        Delivery delivery = Delivery.builder()
+                .address(user.getAddress())
+                .deliveryStatus(DeliveryStatus.PENDING)
+                .build();
+
         // 주문 상품 생성
         List<OrderMenu> orderMenu = OrderMenu.createOrderItem(cartMenus,cartMenuOptionsMap);
 
         // 주문 생성
-        Order order = Order.createOrder(findUser, orderMenu);
+        Order order = Order.createOrder(findUser, delivery, orderMenu);
 
         orderRepository.save(order);
 

--- a/src/main/java/jpabook/dashdine/service/order/OrderService.java
+++ b/src/main/java/jpabook/dashdine/service/order/OrderService.java
@@ -1,0 +1,51 @@
+package jpabook.dashdine.service.order;
+
+import jpabook.dashdine.domain.cart.CartMenu;
+import jpabook.dashdine.domain.order.Order;
+import jpabook.dashdine.domain.order.OrderMenu;
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.repository.order.OrderRepository;
+import jpabook.dashdine.service.cart.query.CartMenuQueryService;
+import jpabook.dashdine.service.user.UserInfoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j(topic = "Order Management Service Log")
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserInfoService userInfoService;
+    private final CartMenuQueryService cartMenuQueryService;
+
+    public void createOrder(User user, List<Long> cartMenuIds) {
+        // 엔티티 조회
+        System.out.println("// ======= 유저 조회 ======= //");
+        User findUser = userInfoService.findUser(user.getLoginId());
+
+        System.out.println("// ======= 장바구니 목록 ======= //");
+        List<CartMenu> cartMenus = cartMenuQueryService.findCartMenus(cartMenuIds);
+
+
+        // 주문 상품 생성
+        System.out.println("// ======= 주문 상품 생성 ======= //");
+        List<OrderMenu> orderMenu = OrderMenu.createOrderItem(cartMenus);
+
+        // 주문 생성
+        System.out.println("// ======= 주문 생성 ======= //");
+        Order order = Order.createOrder(findUser, orderMenu);
+
+        System.out.println("// ======= 주문 저장 ======= //");
+        orderRepository.save(order);
+
+        // 장바구니 비우기
+        System.out.println("// ======= 장바구니 비우기 ======= //");
+        cartMenuQueryService.deleteCartMenus(cartMenus);
+    }
+}


### PR DESCRIPTION
# Description

- 주문 성공 시 해당 품목은 장바니구네에서 삭제

- 메뉴 목록이 존재하지 않으면 주문 간 예외발생

- 장바구니 목록에 존재하는 각 품목의 옵션도 함께 주문

# Issue

**1. 컬렉션 순회 중 발생하는 ConcurrentModificationException 문제 해결**

원인
- order 객체의 orderMenus 리스트를 순회하면서 해당 리스트의 구조를 변경하는 로직이 포함되어 있었음.
- addOrderMenu 메서드에서 orderMenus 리스트에 OrderMenu 객체들을 추가하는 과정에서, updateOrder 메서드 내부에서 다시 order.getOrderMenus().add(this)를 호출함으로써 순회 중인 리스트에 대한 구조적 변경이 발생함.
- 이는 Java 컬렉션 프레임워크가 순회 중인 컬렉션의 동시 변경을 허용하지 않기 때문에 ConcurrentModificationException을 유발.

해결
- addOrderMenu 메서드에서 this.orderMenus.addAll(orderMenus);를 사용하여 기존 리스트에 새로운 OrderMenu 객체들을 추가하는 방식으로 변경.
  이는 기존의 orderMenus 리스트를 새 리스트로 완전히 대체하는 것이 아니라, 추가적으로 포함시키기 위함.

- updateOrder 메서드에서는 this.order를 설정하는 역할만 수행하고, 리스트에 자신을 추가하는 로직(order.getOrderMenus().add(this);)을 제거함.
이로 인해 불필요한 중복 추가 로직을 제거하고, 순회 중인 리스트에 대한 구조적 변경을 방지하여 ConcurrentModificationException 발생을 해결.


**2. N + 1 개선 및 Delete 쿼리 개선**

- 주문 생성 간 장바구니 목록마다 Option 을 조회하는 쿼리가 출력

- 이에 In 절을 통해 목록의 Id 와 관련된 데이터를 한 번에 수집하고, 이후 각 목록을 Key, 이에 매핑된 Option 들을 value 로 가지는 Map 을 생성

- 해당 Map 은 이후 진행될 주문 생성 때  각 목록에 해당하는 option 들을 매핑할 때 사용

- delete 쿼리 진행 간 CartMenu 의 영속성이 CartMenuOption 까지 전파가 안되는 현상 식별

- 이에 먼저 cart_menu_option 을 삭제 후 cart_menu 를 삭제하는 것으로 수정



**3. 주문 생성 간 장바구니에 옵션을 선택하지 않았을 경우 에러 발생 개선** 

- 주문 생성 진행 시 장바구니에 옵션이 존재하지 않을 경우 에러가 발생

- 사용자는 옵션을 선택하지 않을 권리가 있으며, 이를 보장해야함

- 이에 옵션을 선택하지 않은 메뉴는 OrderMenuOption 을 생성하지 않도록 개선