### PR TITLE
feature: 장바구니 추가 기능 개선 ( #27 )

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
+++ b/src/main/java/jpabook/dashdine/controller/cart/CartManagementController.java
@@ -1,6 +1,6 @@
 package jpabook.dashdine.controller.cart;
 
-import jpabook.dashdine.dto.request.cart.CreateCartRequestDto;
+import jpabook.dashdine.dto.request.cart.AddCartParam;
 import jpabook.dashdine.dto.request.cart.UpdateCartRequestDto;
 import jpabook.dashdine.dto.response.ApiResponseDto;
 import jpabook.dashdine.dto.response.cart.CartResponseDto;
@@ -13,8 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @Slf4j(topic = "Cart Management Controller")
@@ -23,9 +21,9 @@ public class CartManagementController {
     private final CartManagementService cartManagementService;
 
     @PostMapping("/cart")
-    public ResponseEntity<ApiResponseDto> addCart(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody CreateCartRequestDto createCartRequestDto) {
+    public ResponseEntity<ApiResponseDto> addCart(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody AddCartParam param) {
 
-        cartManagementService.addCart(userDetails.getUser(), createCartRequestDto);
+        cartManagementService.addCart(userDetails.getUser(), param);
 
         return ResponseEntity.ok().body(new ApiResponseDto("장바구니 담기 성공", HttpStatus.OK.value()));
     }

--- a/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
+++ b/src/main/java/jpabook/dashdine/domain/cart/CartMenu.java
@@ -2,6 +2,8 @@ package jpabook.dashdine.domain.cart;
 
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.menu.Menu;
+import jpabook.dashdine.domain.menu.Option;
+import jpabook.dashdine.dto.request.cart.AddCartParam;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +12,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -34,7 +36,7 @@ public class CartMenu {
     @JoinColumn(name = "menu_id")
     private Menu menu;
 
-    @OneToMany(mappedBy = "cartMenu", cascade = PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "cartMenu", cascade = ALL, orphanRemoval = true)
     private List<CartMenuOption> cartMenuOptions = new ArrayList<>();
 
     @Builder
@@ -42,6 +44,29 @@ public class CartMenu {
         this.count = count;
         this.cart = cart;
         this.menu = menu;
+    }
+
+    public static CartMenu CreateCartMenu(Cart findCart, Menu findMenu, List<Option> findOptions, AddCartParam param) {
+        CartMenu cartMenu = CartMenu.builder()
+                .cart(findCart)
+                .menu(findMenu)
+                .count(param.getCount())
+                .build();
+
+        List<CartMenuOption> cartOptions = findOptions.stream()
+                .map(option -> CartMenuOption.builder()
+                        .cartMenu(cartMenu)
+                        .option(option)
+                        .build())
+                .toList();
+
+        cartMenu.addOptions(cartOptions);
+
+        return cartMenu;
+    }
+
+    private void addOptions(List<CartMenuOption> cartOptions) {
+        this.cartMenuOptions.addAll(cartOptions);
     }
 
     public void increaseCount(int addCount) {

--- a/src/main/java/jpabook/dashdine/dto/request/cart/AddCartParam.java
+++ b/src/main/java/jpabook/dashdine/dto/request/cart/AddCartParam.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Set;
 
 @Getter
 @NoArgsConstructor
-public class CreateCartRequestDto {
+public class AddCartParam {
+    private Long restaurantId;
     private Long menuId;
     private int count;
     private List<Long> options;

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuOptionRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Set;
 
 public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, Long> {
 
@@ -16,8 +15,6 @@ public interface CartMenuOptionRepository extends JpaRepository<CartMenuOption, 
             "left join fetch cmo.option " +
             "where cmo.cartMenu.id in :cartMenuIds")
     List<CartMenuOption> findCartMenuOptionByMenuIds(@Param("cartMenuIds")List<Long> cartMenuIds);
-
-    List<CartMenuOption> findByCartMenuId(Long cartMenuId);
 
     @Modifying
     @Query("delete from CartMenuOption cmo where cmo.cartMenu in :cartMenus")

--- a/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartMenuRepository.java
@@ -7,11 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
-
-    Optional<CartMenu> findByIdAndIsDeletedFalse(Long cartMenuId);
 
     @Query("select cm from CartMenu cm where cm.cart.id = :cartId and cm.menu.id = :menuId")
     List<CartMenu> findByCartIdAndMenuId(@Param("cartId") Long cartId, @Param("menuId") Long menuId);
@@ -24,4 +21,10 @@ public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
     @Modifying
     @Query("delete from CartMenu cm where cm in :cartMenus")
     void deleteAllByCartMenus(@Param("cartMenus") List<CartMenu> cartMenus);
+
+    @Query("select cm from CartMenu cm " +
+            "left join fetch cm.menu " +
+            "where cm.cart.id = :cartId")
+    List<CartMenu> findCartMenusByCartId(@Param("cartId") Long cartId);
 }
+

--- a/src/main/java/jpabook/dashdine/repository/cart/CartRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/cart/CartRepository.java
@@ -11,8 +11,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     Optional<Cart> findByUserId(Long id);
 
     @Query("select c from Cart c " +
-            "left join fetch c.cartMenus cm " +
-            "left join fetch cm.menu " +
             "where c.id = :cartId")
     Cart findWithMenus(@Param("cartId") Long cartId);
 }

--- a/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/cart/query/CartMenuQueryService.java
@@ -46,7 +46,11 @@ public class CartMenuQueryService {
 
 
     public CartMenu findOneCartMenu(Long cartMenuId) {
-        return cartMenuRepository.findByIdAndIsDeletedFalse(cartMenuId)
+        return cartMenuRepository.findById(cartMenuId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+    }
+
+    public List<CartMenu> findCartMenusByCartId(Cart cart) {
+        return cartMenuRepository.findCartMenusByCartId(cart.getId());
     }
 }


### PR DESCRIPTION
# Description

- 장바구니 추가간 동일 가게의 품목만 담을 수 있도록 구현

- 장바구니 생성 로직을 CartMenu 내부에 구현

- 장바구니에 담을 메뉴와 옵션을 조회하기 전에, 검증로직을 수행함으로써, 특정 상황에 대해 불필요한 조회를 피할 수 있음