### PR TITLE
feature: 가게 답글 CRUD 구현 / 가게 별 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
+++ b/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
@@ -3,7 +3,7 @@ package jpabook.dashdine.controller.comment;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
 import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
 import jpabook.dashdine.dto.response.ApiResponseDto;
-import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReplyDetailsForm;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
 import jpabook.dashdine.service.comment.ReplyService;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class ReplyOwnerController {
     }
 
     @GetMapping("/reply")
-    public List<ReplyForm> readAllReplies(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public List<ReplyDetailsForm> readAllReplies(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return replyManagementService.readAllReplies(userDetails.getUser());
     }
 

--- a/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
+++ b/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
@@ -1,7 +1,7 @@
 package jpabook.dashdine.controller.comment;
 
-import jpabook.dashdine.domain.user.UserRoleEnum;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
 import jpabook.dashdine.dto.response.ApiResponseDto;
 import jpabook.dashdine.dto.response.comment.ReplyForm;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
@@ -11,10 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -39,6 +36,25 @@ public class ReplyOwnerController {
     @GetMapping("/reply")
     public List<ReplyForm> readAllReplies(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return replyManagementService.readAllReplies(userDetails.getUser());
+    }
+
+    @PutMapping("/reply/{replyId}")
+    public ResponseEntity<ApiResponseDto> updateReply(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @PathVariable("replyId")Long replyId,
+                                                      @RequestBody UpdateReplyParam param) {
+
+        replyManagementService.updateReply(userDetails.getUser(), replyId, param);
+
+        return ResponseEntity.ok().body(new ApiResponseDto("답글 수정 완료", HttpStatus.OK.value()));
+    }
+
+    @PatchMapping("/reply/{replyId}")
+    public ResponseEntity<ApiResponseDto> deleteReply(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @PathVariable("replyId")Long replyId) {
+
+        replyManagementService.deleteReply(userDetails.getUser(), replyId);
+
+        return ResponseEntity.ok().body(new ApiResponseDto("답글 삭제 완료", HttpStatus.OK.value()));
     }
 
 

--- a/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
+++ b/src/main/java/jpabook/dashdine/controller/comment/ReplyOwnerController.java
@@ -1,0 +1,45 @@
+package jpabook.dashdine.controller.comment;
+
+import jpabook.dashdine.domain.user.UserRoleEnum;
+import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.response.ApiResponseDto;
+import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.security.userdetails.UserDetailsImpl;
+import jpabook.dashdine.service.comment.ReplyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.OWNER;
+
+@RestController
+@RequiredArgsConstructor
+@Secured(OWNER)
+public class ReplyOwnerController {
+
+    private final ReplyService replyManagementService;
+
+    @PostMapping("/reply")
+    public ResponseEntity<ApiResponseDto> createReply(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @RequestBody CreateReplyParam param) {
+
+        replyManagementService.createReply(userDetails.getUser(), param);
+
+        return ResponseEntity.ok().body(new ApiResponseDto("답글 작성 완료", HttpStatus.OK.value()));
+    }
+
+    @GetMapping("/reply")
+    public List<ReplyForm> readAllReplies(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return replyManagementService.readAllReplies(userDetails.getUser());
+    }
+
+
+}

--- a/src/main/java/jpabook/dashdine/controller/restaurant/RestaurantCustomerController.java
+++ b/src/main/java/jpabook/dashdine/controller/restaurant/RestaurantCustomerController.java
@@ -1,9 +1,10 @@
 package jpabook.dashdine.controller.restaurant;
 
 import jpabook.dashdine.dto.request.restaurant.RadiusCondition;
+import jpabook.dashdine.dto.response.comment.RestaurantReviewForm;
 import jpabook.dashdine.dto.response.restaurant.RestaurantForm;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
-import jpabook.dashdine.service.restaurant.RestaurantManagementService;
+import jpabook.dashdine.service.comment.ReviewService;
 import jpabook.dashdine.service.restaurant.RestaurantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
@@ -23,6 +24,7 @@ import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.CUSTOMER;
 public class RestaurantCustomerController {
 
     private final RestaurantService restaurantManagementService;
+    private final ReviewService reviewService;
 
     @GetMapping("/category/{categoryId}/restaurant")
     public List<RestaurantForm> readAllRestaurant(@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -30,5 +32,10 @@ public class RestaurantCustomerController {
                                                   @RequestBody RadiusCondition cond) {
 
         return restaurantManagementService.readAllRestaurant(userDetails.getUser(), categoryId, cond);
+    }
+
+    @GetMapping("/restaurant/{restaurantId}/review")
+    public List<RestaurantReviewForm> readAllReviewFromRestaurant(@PathVariable("restaurantId")Long restaurantId) {
+        return reviewService.readAllReviewFromRestaurant(restaurantId);
     }
 }

--- a/src/main/java/jpabook/dashdine/domain/comment/Reply.java
+++ b/src/main/java/jpabook/dashdine/domain/comment/Reply.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import jpabook.dashdine.domain.common.Timestamped;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -62,4 +65,26 @@ public class Reply extends Timestamped {
         user.getReplies().add(this);
     }
 
+    // == 수정 메서드 == //
+    public void updateReply(User user, UpdateReplyParam param) {
+        validateUser(user);
+
+        if (param.getContent() != null) {
+            this.content = param.getContent();
+        }
+    }
+
+    // == 삭제 메서드 == //
+    public void deleteReply(User user) {
+        validateUser(user);
+        this.isDeleted = false;
+        updateDeletedAt(LocalDateTime.now());
+    }
+
+    // 검증 메서드
+    private void validateUser(User user) {
+        if (!this.user.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+    }
 }

--- a/src/main/java/jpabook/dashdine/domain/comment/Reply.java
+++ b/src/main/java/jpabook/dashdine/domain/comment/Reply.java
@@ -1,0 +1,65 @@
+package jpabook.dashdine.domain.comment;
+
+import jakarta.persistence.*;
+import jpabook.dashdine.domain.common.Timestamped;
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Table(name = "reply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reply extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Builder
+    public Reply(String content, User user, Review review) {
+        this.content = content;
+        updateUser(user);
+        this.review = review;
+    }
+
+    // == 생성 메서드 == //
+    public static Reply createReply(User user, Review findReview, CreateReplyParam param) {
+        if (!user.getRestaurants().contains(findReview.getRestaurant())) {
+            throw new IllegalArgumentException("본인 소유의 가게에만 답글을 남길 수 있습니다.");
+        }
+
+        return Reply.builder()
+                .content(param.getContent())
+                .user(user)
+                .review(findReview)
+                .build();
+    }
+
+    // == 연관관계 메서드 == //
+    private void updateUser(User user) {
+        this.user = user;
+        user.getReplies().add(this);
+    }
+
+}

--- a/src/main/java/jpabook/dashdine/domain/comment/Review.java
+++ b/src/main/java/jpabook/dashdine/domain/comment/Review.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -49,6 +48,9 @@ public class Review extends Timestamped {
     @JoinColumn(name = "restaurant_id")
     @ManyToOne(fetch = LAZY)
     private Restaurant restaurant;
+
+    @OneToOne(mappedBy = "review", cascade = CascadeType.REMOVE)
+    private Reply reply;
 
     @Builder
     public Review(String content, String image, Order order, User user, Restaurant restaurant) {
@@ -91,9 +93,7 @@ public class Review extends Timestamped {
     }
 
     public void updateReview(User user, UpdateReviewParam param) {
-        if (!Objects.equals(this.user.getId(), user.getId())) {
-            throw new IllegalArgumentException("접근 권한이 없습니다.");
-        }
+        validateUser(user);
 
         if (param.getContent() != null) {
             this.content = param.getContent();
@@ -104,8 +104,17 @@ public class Review extends Timestamped {
         }
     }
 
-    public void deleteReview() {
+    public void deleteReview(User user) {
+        validateUser(user);
         this.isDeleted = true;
         updateDeletedAt(LocalDateTime.now());
+    }
+
+
+    // == 검증 메서드 == //
+    private void validateUser(User user) {
+        if (!this.user.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/jpabook/dashdine/domain/user/User.java
+++ b/src/main/java/jpabook/dashdine/domain/user/User.java
@@ -2,6 +2,7 @@ package jpabook.dashdine.domain.user;
 
 import jakarta.persistence.*;
 import jpabook.dashdine.domain.cart.Cart;
+import jpabook.dashdine.domain.comment.Reply;
 import jpabook.dashdine.domain.comment.Review;
 import jpabook.dashdine.domain.common.Address;
 import jpabook.dashdine.domain.common.Timestamped;
@@ -61,6 +62,9 @@ public class User extends Timestamped {
 
     @OneToMany(mappedBy = "user", cascade = REMOVE)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = REMOVE)
+    private List<Reply> replies = new ArrayList<>();
 
     @OneToOne(fetch = LAZY, cascade = ALL)
     @JoinColumn(name = "cart_id")

--- a/src/main/java/jpabook/dashdine/dto/request/comment/CreateReplyParam.java
+++ b/src/main/java/jpabook/dashdine/dto/request/comment/CreateReplyParam.java
@@ -1,0 +1,11 @@
+package jpabook.dashdine.dto.request.comment;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateReplyParam {
+    private Long reviewId;
+    private String content;
+}

--- a/src/main/java/jpabook/dashdine/dto/request/comment/UpdateReplyParam.java
+++ b/src/main/java/jpabook/dashdine/dto/request/comment/UpdateReplyParam.java
@@ -1,0 +1,10 @@
+package jpabook.dashdine.dto.request.comment;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateReplyParam {
+    private String content;
+}

--- a/src/main/java/jpabook/dashdine/dto/response/comment/ReplyDetailsForm.java
+++ b/src/main/java/jpabook/dashdine/dto/response/comment/ReplyDetailsForm.java
@@ -1,0 +1,27 @@
+package jpabook.dashdine.dto.response.comment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReplyDetailsForm {
+
+    @JsonIgnore
+    private Long reviewId;
+    private String content;
+    private LocalDateTime createdTime;
+    private ReviewContentForm reviewContentForm;
+
+    // Projections
+    public ReplyDetailsForm(Long reviewId, String content, LocalDateTime createdTime) {
+        this.reviewId = reviewId;
+        this.content = content;
+        this.createdTime = createdTime;
+    }
+}

--- a/src/main/java/jpabook/dashdine/dto/response/comment/ReplyForm.java
+++ b/src/main/java/jpabook/dashdine/dto/response/comment/ReplyForm.java
@@ -1,27 +1,21 @@
 package jpabook.dashdine.dto.response.comment;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import jpabook.dashdine.domain.comment.Reply;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class ReplyForm {
-
-    @JsonIgnore
-    private Long reviewId;
+    private String username;
     private String content;
     private LocalDateTime createdTime;
-    private ReviewContentForm reviewContentForm;
 
-    // Projections
-    public ReplyForm(Long reviewId, String content, LocalDateTime createdTime) {
-        this.reviewId = reviewId;
-        this.content = content;
-        this.createdTime = createdTime;
+    public ReplyForm(Reply reply) {
+        this.username = reply.getUser().getLoginId();
+        this.content = reply.getContent();
+        this.createdTime = reply.getCreatedAt();
     }
 }

--- a/src/main/java/jpabook/dashdine/dto/response/comment/ReplyForm.java
+++ b/src/main/java/jpabook/dashdine/dto/response/comment/ReplyForm.java
@@ -1,0 +1,27 @@
+package jpabook.dashdine.dto.response.comment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReplyForm {
+
+    @JsonIgnore
+    private Long reviewId;
+    private String content;
+    private LocalDateTime createdTime;
+    private ReviewContentForm reviewContentForm;
+
+    // Projections
+    public ReplyForm(Long reviewId, String content, LocalDateTime createdTime) {
+        this.reviewId = reviewId;
+        this.content = content;
+        this.createdTime = createdTime;
+    }
+}

--- a/src/main/java/jpabook/dashdine/dto/response/comment/RestaurantReviewForm.java
+++ b/src/main/java/jpabook/dashdine/dto/response/comment/RestaurantReviewForm.java
@@ -1,0 +1,31 @@
+package jpabook.dashdine.dto.response.comment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jpabook.dashdine.domain.comment.Reply;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RestaurantReviewForm {
+    @JsonIgnore
+    private Long orderId;
+    private String username;
+    private String restaurantName;
+    private String content;
+    private List<ReviewMenuForm> reviewMenuForms;
+    private ReplyForm replyForm;
+
+    // Projections
+    public RestaurantReviewForm(Long orderId, String username, String restaurantName, String content, Reply reply) {
+        this.orderId = orderId;
+        this.username = username;
+        this.restaurantName = restaurantName;
+        this.content = content;
+        this.replyForm = new ReplyForm(reply);
+    }
+}

--- a/src/main/java/jpabook/dashdine/dto/response/comment/ReviewContentForm.java
+++ b/src/main/java/jpabook/dashdine/dto/response/comment/ReviewContentForm.java
@@ -1,0 +1,30 @@
+package jpabook.dashdine.dto.response.comment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jpabook.dashdine.domain.comment.Review;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReviewContentForm {
+    @JsonIgnore
+    private Long reviewId;
+    @JsonIgnore
+    private Long restaurantId;
+    private String restaurantName;
+    private String content;
+    private LocalDateTime createdTime;
+
+    public ReviewContentForm(Review review) {
+        this.reviewId = review.getId();
+        this.restaurantId = review.getRestaurant().getId();
+        this.restaurantName = review.getRestaurant().getName();
+        this.content = review.getContent();
+        this.createdTime = review.getCreatedAt();
+    }
+}

--- a/src/main/java/jpabook/dashdine/repository/comment/ReplyRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/ReplyRepository.java
@@ -3,6 +3,13 @@ package jpabook.dashdine.repository.comment;
 import jpabook.dashdine.domain.comment.Reply;
 import jpabook.dashdine.repository.comment.custom.ReplyCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long>, ReplyCustomRepository {
+
+    @Query("select r from Reply r where r.id = :replyId and r.isDeleted = false")
+    Optional<Reply> findReplyById(@Param("replyId") Long replyId);
 }

--- a/src/main/java/jpabook/dashdine/repository/comment/ReplyRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/ReplyRepository.java
@@ -1,0 +1,8 @@
+package jpabook.dashdine.repository.comment;
+
+import jpabook.dashdine.domain.comment.Reply;
+import jpabook.dashdine.repository.comment.custom.ReplyCustomRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long>, ReplyCustomRepository {
+}

--- a/src/main/java/jpabook/dashdine/repository/comment/ReviewRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/ReviewRepository.java
@@ -18,4 +18,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findReviewsByUserId(@Param("userId") Long userId);
 
     Optional<Review> findReviewByIdAndIsDeletedFalse(Long reviewId);
+
+    @Query("select r from Review r " +
+            "left join fetch r.restaurant " +
+            "where r.id in :reviewIds and r.isDeleted = false")
+    List<Review> findReviewsByReviewIdIn(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/src/main/java/jpabook/dashdine/repository/comment/ReviewRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/ReviewRepository.java
@@ -1,6 +1,7 @@
 package jpabook.dashdine.repository.comment;
 
 import jpabook.dashdine.domain.comment.Review;
+import jpabook.dashdine.repository.comment.custom.ReviewCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCustomRepository {
 
     @Query("select r from Review r " +
             "left join fetch r.restaurant " +

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepository.java
@@ -1,0 +1,9 @@
+package jpabook.dashdine.repository.comment.custom;
+
+import jpabook.dashdine.dto.response.comment.ReplyForm;
+
+import java.util.List;
+
+public interface ReplyCustomRepository {
+    List<ReplyForm> findReplyFormsByUserId(Long userId);
+}

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepository.java
@@ -1,9 +1,9 @@
 package jpabook.dashdine.repository.comment.custom;
 
-import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReplyDetailsForm;
 
 import java.util.List;
 
 public interface ReplyCustomRepository {
-    List<ReplyForm> findReplyFormsByUserId(Long userId);
+    List<ReplyDetailsForm> findReplyFormsByUserId(Long userId);
 }

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepositoryImpl.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package jpabook.dashdine.repository.comment.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jpabook.dashdine.dto.response.comment.ReplyForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static jpabook.dashdine.domain.comment.QReply.reply;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyCustomRepositoryImpl implements ReplyCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ReplyForm> findReplyFormsByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(ReplyForm.class,
+                        reply.review.id,
+                        reply.content,
+                        reply.createdAt))
+                .from(reply)
+                .where(reply.user.id.eq(userId)
+                        .and(reply.isDeleted.eq(false)))
+                .fetch();
+    }
+
+}

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepositoryImpl.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReplyCustomRepositoryImpl.java
@@ -2,7 +2,7 @@ package jpabook.dashdine.repository.comment.custom;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReplyDetailsForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,9 +17,9 @@ public class ReplyCustomRepositoryImpl implements ReplyCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<ReplyForm> findReplyFormsByUserId(Long userId) {
+    public List<ReplyDetailsForm> findReplyFormsByUserId(Long userId) {
         return jpaQueryFactory
-                .select(Projections.constructor(ReplyForm.class,
+                .select(Projections.constructor(ReplyDetailsForm.class,
                         reply.review.id,
                         reply.content,
                         reply.createdAt))

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepository.java
@@ -1,0 +1,9 @@
+package jpabook.dashdine.repository.comment.custom;
+
+import jpabook.dashdine.dto.response.comment.RestaurantReviewForm;
+
+import java.util.List;
+
+public interface ReviewCustomRepository {
+    List<RestaurantReviewForm> findRestaurantReviewFormByRestaurantId(Long restaurantId);
+}

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepositoryImpl.java
@@ -1,0 +1,33 @@
+package jpabook.dashdine.repository.comment.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jpabook.dashdine.dto.response.comment.RestaurantReviewForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static jpabook.dashdine.domain.comment.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCustomRepositoryImpl implements ReviewCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<RestaurantReviewForm> findRestaurantReviewFormByRestaurantId(Long restaurantId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(RestaurantReviewForm.class,
+                        review.order.id,
+                        review.user.loginId,
+                        review.restaurant.name,
+                        review.content,
+                        review.reply))
+                .from(review)
+                .where(review.restaurant.id.eq(restaurantId)
+                        .and(review.isDeleted.eq(false)))
+                .fetch();
+    }
+}

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
@@ -4,6 +4,7 @@ import jpabook.dashdine.domain.comment.Reply;
 import jpabook.dashdine.domain.comment.Review;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
 import jpabook.dashdine.dto.response.comment.ReplyForm;
 import jpabook.dashdine.dto.response.comment.ReviewContentForm;
 import jpabook.dashdine.repository.comment.ReplyRepository;
@@ -54,6 +55,21 @@ public class ReplyManagementService implements ReplyService {
         return replyForms;
     }
 
+    @Override
+    public void updateReply(User user, Long replyId, UpdateReplyParam param) {
+        // 답글 조회
+        Reply findReply = getReply(replyId);
+
+        findReply.updateReply(user, param);
+    }
+
+    @Override
+    public void deleteReply(User user, Long replyId) {
+        Reply findReply = getReply(replyId);
+
+        findReply.deleteReply(user);
+    }
+
     private Map<Long, ReviewContentForm> getLongReviewContentFormMap(List<ReplyForm> replyForms) {
         List<Review> reviews = reviewQueryService.findAllReviews(getReviewIds(replyForms));
 
@@ -66,5 +82,10 @@ public class ReplyManagementService implements ReplyService {
         return replyForms.stream()
                 .map(ReplyForm::getReviewId)
                 .collect(Collectors.toList());
+    }
+
+    private Reply getReply(Long replyId) {
+        return replyRepository.findReplyById(replyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
     }
 }

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
@@ -1,0 +1,70 @@
+package jpabook.dashdine.service.comment;
+
+import jpabook.dashdine.domain.comment.Reply;
+import jpabook.dashdine.domain.comment.Review;
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReviewContentForm;
+import jpabook.dashdine.repository.comment.ReplyRepository;
+import jpabook.dashdine.service.comment.query.ReviewQueryService;
+import jpabook.dashdine.service.user.query.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReplyManagementService implements ReplyService {
+
+    private final ReplyRepository replyRepository;
+    private final ReviewQueryService reviewQueryService;
+    private final UserQueryService userQueryService;
+
+    @Override
+    public void createReply(User user, CreateReplyParam param) {
+        // 유저 조회
+        User findUser = userQueryService.findUser(user.getLoginId());
+
+        // 리뷰 조회
+        Review findReview = reviewQueryService.findOneReview(param.getReviewId());
+
+        // 답글 생성
+        Reply reply = Reply.createReply(findUser, findReview, param);
+
+        replyRepository.save(reply);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReplyForm> readAllReplies(User user) {
+        // 답글 조회
+        List<ReplyForm> replyForms = replyRepository.findReplyFormsByUserId(user.getId());
+
+        Map<Long, ReviewContentForm> reviewContentFormMap = getLongReviewContentFormMap(replyForms);
+
+        replyForms.forEach(rf -> rf.setReviewContentForm(reviewContentFormMap.get(rf.getReviewId())));
+
+        return replyForms;
+    }
+
+    private Map<Long, ReviewContentForm> getLongReviewContentFormMap(List<ReplyForm> replyForms) {
+        List<Review> reviews = reviewQueryService.findAllReviews(getReviewIds(replyForms));
+
+        return reviews.stream()
+                .map(ReviewContentForm::new)
+                .collect(Collectors.toMap(ReviewContentForm::getReviewId, Function.identity()));
+    }
+
+    private static List<Long> getReviewIds(List<ReplyForm> replyForms) {
+        return replyForms.stream()
+                .map(ReplyForm::getReviewId)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyManagementService.java
@@ -5,7 +5,7 @@ import jpabook.dashdine.domain.comment.Review;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
 import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
-import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReplyDetailsForm;
 import jpabook.dashdine.dto.response.comment.ReviewContentForm;
 import jpabook.dashdine.repository.comment.ReplyRepository;
 import jpabook.dashdine.service.comment.query.ReviewQueryService;
@@ -44,15 +44,15 @@ public class ReplyManagementService implements ReplyService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ReplyForm> readAllReplies(User user) {
+    public List<ReplyDetailsForm> readAllReplies(User user) {
         // 답글 조회
-        List<ReplyForm> replyForms = replyRepository.findReplyFormsByUserId(user.getId());
+        List<ReplyDetailsForm> replyDetailsForms = replyRepository.findReplyFormsByUserId(user.getId());
 
-        Map<Long, ReviewContentForm> reviewContentFormMap = getLongReviewContentFormMap(replyForms);
+        Map<Long, ReviewContentForm> reviewContentFormMap = getLongReviewContentFormMap(replyDetailsForms);
 
-        replyForms.forEach(rf -> rf.setReviewContentForm(reviewContentFormMap.get(rf.getReviewId())));
+        replyDetailsForms.forEach(rf -> rf.setReviewContentForm(reviewContentFormMap.get(rf.getReviewId())));
 
-        return replyForms;
+        return replyDetailsForms;
     }
 
     @Override
@@ -70,17 +70,17 @@ public class ReplyManagementService implements ReplyService {
         findReply.deleteReply(user);
     }
 
-    private Map<Long, ReviewContentForm> getLongReviewContentFormMap(List<ReplyForm> replyForms) {
-        List<Review> reviews = reviewQueryService.findAllReviews(getReviewIds(replyForms));
+    private Map<Long, ReviewContentForm> getLongReviewContentFormMap(List<ReplyDetailsForm> replyDetailsForms) {
+        List<Review> reviews = reviewQueryService.findAllReviews(getReviewIds(replyDetailsForms));
 
         return reviews.stream()
                 .map(ReviewContentForm::new)
                 .collect(Collectors.toMap(ReviewContentForm::getReviewId, Function.identity()));
     }
 
-    private static List<Long> getReviewIds(List<ReplyForm> replyForms) {
-        return replyForms.stream()
-                .map(ReplyForm::getReviewId)
+    private static List<Long> getReviewIds(List<ReplyDetailsForm> replyDetailsForms) {
+        return replyDetailsForms.stream()
+                .map(ReplyDetailsForm::getReviewId)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
@@ -1,0 +1,14 @@
+package jpabook.dashdine.service.comment;
+
+import jpabook.dashdine.domain.user.User;
+import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.response.comment.ReplyForm;
+
+import java.util.List;
+
+public interface ReplyService {
+
+    void createReply(User user, CreateReplyParam param);
+
+    List<ReplyForm> readAllReplies(User user);
+}

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
@@ -3,7 +3,7 @@ package jpabook.dashdine.service.comment;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
 import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
-import jpabook.dashdine.dto.response.comment.ReplyForm;
+import jpabook.dashdine.dto.response.comment.ReplyDetailsForm;
 
 import java.util.List;
 
@@ -13,7 +13,7 @@ public interface ReplyService {
     void createReply(User user, CreateReplyParam param);
 
     // 답글 조회
-    List<ReplyForm> readAllReplies(User user);
+    List<ReplyDetailsForm> readAllReplies(User user);
 
     // 답글 수정
     void updateReply(User user, Long replyId, UpdateReplyParam param);

--- a/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReplyService.java
@@ -2,13 +2,22 @@ package jpabook.dashdine.service.comment;
 
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReplyParam;
+import jpabook.dashdine.dto.request.comment.UpdateReplyParam;
 import jpabook.dashdine.dto.response.comment.ReplyForm;
 
 import java.util.List;
 
 public interface ReplyService {
 
+    // 답글 생성
     void createReply(User user, CreateReplyParam param);
 
+    // 답글 조회
     List<ReplyForm> readAllReplies(User user);
+
+    // 답글 수정
+    void updateReply(User user, Long replyId, UpdateReplyParam param);
+
+    // 답글 삭제
+    void deleteReply(User user, Long replyId);
 }

--- a/src/main/java/jpabook/dashdine/service/comment/ReviewService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReviewService.java
@@ -3,6 +3,7 @@ package jpabook.dashdine.service.comment;
 import jpabook.dashdine.domain.user.User;
 import jpabook.dashdine.dto.request.comment.CreateReviewParam;
 import jpabook.dashdine.dto.request.comment.UpdateReviewParam;
+import jpabook.dashdine.dto.response.comment.RestaurantReviewForm;
 import jpabook.dashdine.dto.response.comment.ReviewForm;
 
 import java.util.List;
@@ -14,6 +15,9 @@ public interface ReviewService {
 
     // 리뷰 조회
     List<ReviewForm> readAllReview(User user);
+
+    // 가게 리뷰 조회
+    List<RestaurantReviewForm> readAllReviewFromRestaurant(Long restaurantId);
 
     // 리뷰 수정
     ReviewForm updateReview(User user, Long reviewId, UpdateReviewParam param);

--- a/src/main/java/jpabook/dashdine/service/comment/query/ReviewQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/query/ReviewQueryService.java
@@ -1,0 +1,24 @@
+package jpabook.dashdine.service.comment.query;
+
+import jpabook.dashdine.domain.comment.Review;
+import jpabook.dashdine.repository.comment.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryService {
+
+    private final ReviewRepository reviewRepository;
+
+    public Review findOneReview(Long reviewId) {
+        return reviewRepository.findReviewByIdAndIsDeletedFalse(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+    }
+
+    public List<Review> findAllReviews(List<Long> reviewIds) {
+        return reviewRepository.findReviewsByReviewIdIn(reviewIds);
+    }
+}


### PR DESCRIPTION
# Description

1. 답글 생성 기능

- Reply 엔티티에 답글 생성을 위한 빌더 메소드와 정적 팩토리 메소드 구현.

- ReplyManagementService에 답글 생성 로직을 처리하는 createReply 메소드 추가.

- 사용자와 리뷰 정보를 검증하여 조건에 맞는 경우에만 답글 생성을 허용.

2. 답글 조회 기능

- ReplyRepository에 사용자 ID를 기준으로 답글을 조회하는 findReplyFormsByUserId 쿼리 메소드 추가.

- ReplyForm과 ReviewContentForm DTO 클래스 구현하여 답글과 관련된 리뷰 정보 전달.

- ReplyManagementService에 답글 조회 로직을 처리하는 readAllReplies 메소드 추가.

- 조회된 답글에 대한 리뷰 정보를 맵핑하여 리턴.

3. 수정 및 삭제

- Reply 엔티티에 답글의 내용을 업데이트하는 updateReply 메소드 구현.

- Reply 엔티티에 답글을 삭제 상태로 변경하는 deleteReply 메소드 구현.

- ReplyService 인터페이스에 답글 수정 및 삭제를 위한 메소드 정의.

- ReplyManagementService에 답글 수정 및 삭제 로직을 처리하는 updateReply 및 deleteReply 메소드 구현.

- 답글 작성자만 답글을 수정하거나 삭제할 수 있도록 접근 권한 검증 로직 추가.

4. 가게 별 리뷰 조회

- ReviewCustomRepository에 가게 ID를 기준으로 가게 리뷰 조회 쿼리 메소드 findRestaurantReviewFormByRestaurantId 구현.

- ReviewService에 가게 리뷰를 조회하고 처리하는 로직을 포함한 readAllReviewFromRestaurant 메소드 추가.

- RestaurantCustomerController에 가게 리뷰를 조회하는 REST API 엔드포인트 '/restaurant/{restaurantId}/review' 추가.

- 조회된 리뷰 정보에 따라 ReviewMenuForm 데이터를 매핑하여 최종 응답 데이터 구성.

- 리뷰 조회 시 isDeleted가 false인 리뷰만을 대상으로 하여 삭제되지 않은 리뷰만 반환하도록 구현.