### PR TITLE
feature: 장바구니 생성 및 업데이트 로직 개선 ( #45 )

### DIFF
--- a/src/main/java/jpabook/dashdine/dto/request/cart/AddCartParam.java
+++ b/src/main/java/jpabook/dashdine/dto/request/cart/AddCartParam.java
@@ -3,7 +3,8 @@ package jpabook.dashdine.dto.request.cart;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -11,5 +12,5 @@ public class AddCartParam {
     private Long restaurantId;
     private Long menuId;
     private int count;
-    private List<Long> options;
+    private Set<Long> options = new HashSet<>();
 }

--- a/src/main/java/jpabook/dashdine/dto/request/cart/UpdateCartParam.java
+++ b/src/main/java/jpabook/dashdine/dto/request/cart/UpdateCartParam.java
@@ -3,11 +3,11 @@ package jpabook.dashdine.dto.request.cart;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
 public class UpdateCartParam {
     private int count;
-    private List<Long> options;
+    private Set<Long> options;
 }

--- a/src/main/java/jpabook/dashdine/repository/menu/OptionRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/menu/OptionRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface OptionRepository extends JpaRepository<Option, Long> {
 
 
-    List<Option> findByIdIn(List<Long> optionId);
+    List<Option> findByIdIn(Set<Long> optionId);
 
     @Query("select o.content from Option o where o.menu.id = :menuId")
     List<String> findOptionContent(@Param("menuId")Long menuId);

--- a/src/main/java/jpabook/dashdine/service/menu/query/OptionQueryService.java
+++ b/src/main/java/jpabook/dashdine/service/menu/query/OptionQueryService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +16,7 @@ public class OptionQueryService {
 
     private final OptionRepository optionRepository;
 
-    public List<Option> findOptions(List<Long> optionIds) {
+    public List<Option> findOptions(Set<Long> optionIds) {
         return optionRepository.findByIdIn(optionIds);
     }
 


### PR DESCRIPTION
# Description

- AddCartParam 및 UpdateCartParam 클래스에서 옵션 목록 타입을 List에서 Set으로 변경하여 중복 옵션 제거 및 검증 로직 단순화.

- 장바구니 메뉴와 옵션 검증 로직에서 요청한 옵션이 기존 장바구니 옵션에 존재하지 않는 경우 제거하는 로직 추가.

- 요청한 옵션의 구성이 기존 장바구니 내 항목과 일치하는 경우에는 수량만 업데이트하고, 그렇지 않은 경우에는 새로운 옵션을 추가하는 로직으로 개선.

- 기존 장바구니 메뉴 옵션과 요청한 옵션의 일치 여부를 판단하는 validateCart 메소드 추가.

- 요청 DTO의 옵션 타입을 Set으로 변경하여 옵션 ID 목록의 중복을 자동으로 처리하고, 검증 과정에서의 성능을 향상.