### PR TITLE
feature: 식당 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/jpabook/dashdine/controller/restaurant/RestaurantOwnerController.java
+++ b/src/main/java/jpabook/dashdine/controller/restaurant/RestaurantOwnerController.java
@@ -4,8 +4,10 @@ import jakarta.validation.Valid;
 import jpabook.dashdine.dto.request.restaurant.CreateRestaurantParam;
 import jpabook.dashdine.dto.request.restaurant.UpdateRestaurantParam;
 import jpabook.dashdine.dto.response.ApiResponseDto;
+import jpabook.dashdine.dto.response.comment.RestaurantReviewForm;
 import jpabook.dashdine.dto.response.restaurant.RestaurantForm;
 import jpabook.dashdine.security.userdetails.UserDetailsImpl;
+import jpabook.dashdine.service.comment.ReviewService;
 import jpabook.dashdine.service.restaurant.RestaurantService;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.io.ParseException;
@@ -27,6 +29,7 @@ import static jpabook.dashdine.domain.user.UserRoleEnum.Authority.OWNER;
 public class RestaurantOwnerController {
 
     private final RestaurantService restaurantManagementService;
+    private final ReviewService reviewManagementService;
 
     @PostMapping("/restaurant")
     public ResponseEntity<ApiResponseDto> createRestaurant(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody @Valid CreateRestaurantParam param) throws ParseException {
@@ -37,6 +40,11 @@ public class RestaurantOwnerController {
     @GetMapping("/restaurant")
     public List<RestaurantForm> readAllRestaurant(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return restaurantManagementService.readAllRestaurant(userDetails.getUser());
+    }
+
+    @GetMapping("/restaurant/review")
+    public List<RestaurantReviewForm> readAllReviewFromRestaurant(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return reviewManagementService.readAllReviewFromUser(userDetails.getUser());
     }
 
     @PutMapping("/restaurant/{restaurantId}")

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepository.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ReviewCustomRepository {
     List<RestaurantReviewForm> findRestaurantReviewFormByRestaurantId(Long restaurantId);
+
+    List<RestaurantReviewForm> findRestaurantReviewFormByUserId(Long userId);
 }

--- a/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/jpabook/dashdine/repository/comment/custom/ReviewCustomRepositoryImpl.java
@@ -28,6 +28,24 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository{
                 .from(review)
                 .where(review.restaurant.id.eq(restaurantId)
                         .and(review.isDeleted.eq(false)))
+                .orderBy(review.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<RestaurantReviewForm> findRestaurantReviewFormByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(RestaurantReviewForm.class,
+                        review.order.id,
+                        review.user.loginId,
+                        review.restaurant.name,
+                        review.content,
+                        review.reply
+                        ))
+                .from(review)
+                .where(review.restaurant.user.id.eq(userId)
+                        .and(review.isDeleted.eq(false)))
+                .orderBy(review.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/jpabook/dashdine/service/comment/ReviewManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReviewManagementService.java
@@ -83,6 +83,22 @@ public class ReviewManagementService implements ReviewService {
         return findRestaurantReviewForms;
     }
 
+    // 본인 가게 리뷰 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<RestaurantReviewForm> readAllReviewFromUser(User user) {
+        // 리뷰 폼 조회
+        List<RestaurantReviewForm> findRestaurantReviewForms = reviewRepository.findRestaurantReviewFormByUserId(user.getId());
+
+        // 맵 생성
+        Map<Long, List<ReviewMenuForm>> reviewMenuFormMap = getReviewMenuFormMap(findRestaurantReviewForms);
+
+        // 매핑
+        findRestaurantReviewForms.forEach(rrf -> rrf.setReviewMenuForms(reviewMenuFormMap.get(rrf.getOrderId())));
+
+        return findRestaurantReviewForms;
+    }
+
 
     // 리뷰 수정
     @Override

--- a/src/main/java/jpabook/dashdine/service/comment/ReviewManagementService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReviewManagementService.java
@@ -17,8 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -146,9 +148,12 @@ public class ReviewManagementService implements ReviewService {
     private List<ReviewMenuForm> getReviewMenuForms(List<Long> orderIds) {
         List<OrderMenu> findOrderMenus = orderMenuQueryService.findAllOrderMenusByOrderIds(orderIds);
 
+        Set<Long> uniqueMenuIds = new HashSet<>();
+
         return findOrderMenus.stream()
+                .filter(om -> uniqueMenuIds.add(om.getMenu().getId()))
                 .map(ReviewMenuForm::new)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     private Review getReview(Long reviewId) {

--- a/src/main/java/jpabook/dashdine/service/comment/ReviewService.java
+++ b/src/main/java/jpabook/dashdine/service/comment/ReviewService.java
@@ -19,6 +19,9 @@ public interface ReviewService {
     // 가게 리뷰 조회
     List<RestaurantReviewForm> readAllReviewFromRestaurant(Long restaurantId);
 
+    // 본인 가게 리뷰 조회
+    List<RestaurantReviewForm> readAllReviewFromUser(User user);
+
     // 리뷰 수정
     ReviewForm updateReview(User user, Long reviewId, UpdateReviewParam param);
 


### PR DESCRIPTION
# Description

- ReviewRepository에 사용자 ID를 파라미터로 받아, 소유 가게의 리뷰를 조회하는 findRestaurantReviewFormByUserId 메소드를 추가

- 각 리뷰에 대해 해당 리뷰가 속한 주문의 메뉴 옵션 정보를 포함시키기 위해 getReviewMenuFormMap 메소드를 통해 메뉴 옵션 정보 맵을 생성하고, 이를 RestaurantReviewForm 객체에 매핑

- 주문 메뉴 조회 시 중복되는 메뉴를 제거하는 로직을 getReviewMenuForms 메소드에 추가

- Set을 활용하여 이미 처리된 메뉴 ID를 추적하고, 중복된 메뉴 ID를 가진 OrderMenu 객체를 스트림 처리 과정에서 걸러내도록 구현

- 각 주문에 대한 고유한 메뉴 목록만을 ReviewMenuForm 리스트로 반환하도록 개선